### PR TITLE
feat(oauth): user management improvements (GitHub/Google services, email & account handling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 ## NoteHub versão alpha (backend)
 
 #### NoteHub é um projeto open-source que fornece uma API REST escrita em Java + Spring Boot para um "Bloco de Notas Social". A ideia é oferecer uma base escalável e extensível para criar, compartilhar e processar notas, com autenticação JWT, persistência em PostgreSQL e processamento assíncrono via RabbitMQ. O projeto foi estruturado para ser simples de entender e fácil de contribuir — perfeito para colaboradores que queiram se desenvolver em um contexto real.
@@ -12,7 +11,7 @@
 </div>
 <br>
 <div align="center">
-  <a href="https://github.com/notehubbr/notehub-api/releases/tag/v1.0">
+  <a href="https://github.com/notehubbr/notehub-api/releases/tag/v1.5">
     <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-v1.0-7c3aed">
   </a>
 </div>
@@ -23,52 +22,56 @@
 
   <summary>Build</summary>
 
-  #### Pré-requisitos(build):
-  
-  - Git
-  - Docker
-  
-  1. Digite os seguintes comandos no terminal dentro da pasta desejada:
+#### Pré-requisitos(build):
+
+- Git
+- Docker
+
+1. Digite os seguintes comandos no terminal dentro da pasta desejada:
+
   ```bash
     git clone https://github.com/notehubbr/notehub-api.git
     cd springboot-notehub
   ```
 
-  2. Copie o arquivo de exemplo de variáveis de ambiente e ajuste conforme necessário:
+2. Copie o arquivo de exemplo de variáveis de ambiente e ajuste conforme necessário:
+
   ```bash
     (Linux e macOS) cp .env.example .env
     (Windows) copy .env.example .env
   ```
 
-  3. Suba a aplicação com Docker Compose:
+3. Suba a aplicação com Docker Compose:
+
   ```bash
     docker compose up -d
   ```
 
-  4. Acesse a API em `http://localhost:8080` (por padrão). A documentação interativa normalmente fica em `http://localhost:8080/docs`.
+4. Acesse a API em `http://localhost:8080` (por padrão). A documentação interativa normalmente fica em `http://localhost:8080/docs`.
 
-  5. Para parar e remover containers:
+5. Para parar e remover containers:
+
   ```bash
     docker compose down --rmi all --volumes
   ```
-  
+
 </details>
 
 <details>
 
   <summary>Dev</summary>
 
-  #### Pré-requisitos(dev):
+#### Pré-requisitos(dev):
 
-  - Git
-  - Docker
-  - Java 21
+- Git
+- Docker
+- Java 21
 
-  1. Siga as intruções do build até a parte 2(faça a parte 2).
+1. Siga as intruções do build até a parte 2(faça a parte 2).
 
-  2. Em docker-compose.yml comente os blocos:
+2. Em docker-compose.yml comente os blocos:
 
-  > Em ambiente de desenvolvimento será utilizado o banco de dados em memória e a aplicação será executada pela IDE.
+> Em ambiente de desenvolvimento será utilizado o banco de dados em memória e a aplicação será executada pela IDE.
 
   ```docker
   # postgres:
@@ -101,98 +104,113 @@
   #   postgres_data:
   ```
 
-  3. Suba a aplicação com Docker Compose:
+3. Suba a aplicação com Docker Compose:
+
   ```bash
     docker compose up -d
   ```
 
-  4. Em `src/main/resources/application-dev.properties` preencha os valores das variáveis de ambiente:
-  > O arquivo .env só atende ao ambiente de produção.
+4. Em `src/main/resources/application-dev.properties` preencha os valores das variáveis de ambiente:
+
+> O arquivo .env só atende ao ambiente de produção.
+
   ```properties
     api.server.host=${SERVER:http://localhost:8080}
-    api.client.host=${http://localhost:3000}
-    api.server.security.token.secret=${SECRET:seu-segredo}
-    
-    oauth.github.client.id=${GHCI:seu-github-client-id}
-    oauth.github.client.secret=${GHCS:seu-github-client-secret}
-    
-    spring.rabbitmq.addresses=${RABBITMQ_ADDRESSES:amqp://user:root@rabbitmq:5672}
-    broker.queue.activation.name=default.activation
-    broker.queue.password.name=default.password
-    broker.queue.email.name=default.email
-    
-    spring.mail.host=${SPRING_MAIL_HOST:mailhog}
-    spring.mail.port=${SPRING_MAIL_PORT:1025}
-    spring.mail.friendly.name=${SPRING_MAIL_FRIENDLY_NAME:seu-nome-amigável}
-    spring.mail.username=${SPRING_MAIL_USERNAME:seu-email-de-teste}
-    spring.mail.password=${SPRING_MAIL_PASSWORD:}
+api.client.host=${http://localhost:3000}
+api.server.security.token.secret=${SECRET:seu-segredo}
+oauth.github.client.id=${GHCI:seu-github-client-id}
+oauth.github.client.secret=${GHCS:seu-github-client-secret}
+spring.rabbitmq.addresses=${RABBITMQ_ADDRESSES:amqp://user:root@localhost:5672}
+broker.queue.activation.name=default.activation
+broker.queue.secret.name=default.secret
+broker.queue.password.name=default.password
+broker.queue.email.name=default.email
+spring.mail.host=${SPRING_MAIL_HOST:localhost}
+spring.mail.port=${SPRING_MAIL_PORT:1025}
+spring.mail.friendly.name=${SPRING_MAIL_FRIENDLY_NAME:seu-nome-amigável}
+spring.mail.username=${SPRING_MAIL_USERNAME:email-genérico}
+spring.mail.password=${SPRING_MAIL_PASSWORD:}
   ```
 
-  5. Em `src/main/java/br/com/notehub/domain/notification/Notification.java` comente a seguinte parte:
-  > O banco de dados em memória não oferece suporte ao tipo de coluna JSON/JSONB.
+5. Em `src/main/java/br/com/notehub/domain/notification/Notification.java` comente a seguinte parte:
+
+> O banco de dados em memória não oferece suporte ao tipo de coluna JSON/JSONB.
+
   ```java
     // @Column(columnDefinition = "JSONB")
-    // @JdbcTypeCode(SqlTypes.JSON)
-    @Convert(converter = NotificationFieldInfoConverter.class)
-    private Map<String, Object> info;
+// @JdbcTypeCode(SqlTypes.JSON)
+@Convert(converter = NotificationFieldInfoConverter.class)
+private Map<String, Object> info;
   ```
 
-  6. Inicie a aplicação.
+6. Inicie a aplicação.
+
   ```bash
     ./mvnw spring-boot:run
   ```
 
-  7. Acesse a API em `http://localhost:8080` (por padrão). A documentação interativa normalmente fica em `http://localhost:8080/docs`.
+7. Acesse a API em `http://localhost:8080` (por padrão). A documentação interativa normalmente fica em `http://localhost:8080/docs`.
 
-  8. Para acessar a caixa de e-mails acesse `http://localhost:8025`.
+8. Para acessar a caixa de e-mails acesse `http://localhost:8025`.
 
-  9. Para parar e remover containers acione `CTRL+C` no terminal e em seguide digite:
+9. Para parar e remover containers acione `CTRL+C` no terminal e em seguide digite:
+
   ```bash
     docker compose down --rmi all --volumes
   ```
-  
+
 </details>
 
 ## Documentação
+
 #### A API é documentada em Swagger e acessível em <a href="https://api.notehub.com.br/docs">/docs</a>
 
 ## Relato de erros
+
 #### Use o sistema de Issues do GitHub, crie uma issue com passos para reproduzir, comportamento esperado e logs/erros.
 
 ## Sugestão
+
 #### Deixe um comentário com a nova ideia/sugestão na <a href="https://notehub.com.br/notehub/52b89a65-1c87-4692-9bf8-5096b674fa40">postagem dedicada.</a>
 
 ## Contribuição
+
 #### Contribuições são mais do que bem-vindas! Aqui vai um fluxo sugerido para colaboradores:
 
-  1. Fork -> clone -> crie uma branch com um nome descritivo:
+1. Fork -> clone -> crie uma branch com um nome descritivo:
+
   ```bash
     git checkout -b feat/nova-funcionalidade
   ```
 
-  2. Faça commits em inglês, pequenos e claros seguindo o padrão: `(emoji) (escopo)(referência):(mensagem)`. Ex.:
+2. Faça commits em inglês, pequenos e claros seguindo o padrão: `(escopo)(referência):(mensagem)`. Ex.:
+
   ```bash
-    git commit -m "✨ feat(auth): add login via Discord"
+    git commit -m "feat(auth): add login via Discord"
   ```
 
-  3. Sincronize com o upstream (se estiver forked) e abra um Pull Request descrevendo:
-  - O que foi alterado;
-  - Porquê a alteração é necessária;
-  - Como testar manualmente;
+3. Sincronize com o upstream (se estiver forked) e abra um Pull Request descrevendo:
 
-  4. Preencha checklist no PR:
-  - [ ] Código segue o padrão do projeto
-  - [ ] Testes adicionados/atualizados
-  - [ ] Documentação atualizada (se necessário)
+- O que foi alterado;
+- Porquê a alteração é necessária;
+- Como testar manualmente;
 
-  5. Boas práticas para PRs
-  - Um propósito por PR (não agrupe várias funcionalidades sem relação).
-  - Inclua screenshots ou curl/postman snippets quando possível.
-  - Referencie a issue correspondente (ex.: Fixes #12).
+4. Preencha checklist no PR:
+
+- [x] Código segue o padrão do projeto
+- [ ] Testes adicionados/atualizados
+- [x] Documentação atualizada (se necessário)
+
+5. Boas práticas para PRs
+
+- Um propósito por PR (não agrupe várias funcionalidades sem relação).
+- Inclua screenshots ou curl/postman snippets quando possível.
+- Referencie a issue correspondente (ex.: Fixes #12).
 
 ## Licença
+
 #### Ainda não há licença explícita no repositório.
 
 ## Créditos
 
-  - ###### Email Template por <a href="https://github.com/konsav/email-templates">***konsav***</a>
+- ###### Email Template por <a href="https://github.com/konsav/email-templates">***konsav***</a>

--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-mail</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.15.2</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/br/com/notehub/adapter/consumer/dto/SecretKeyGenerationDTO.java
+++ b/src/main/java/br/com/notehub/adapter/consumer/dto/SecretKeyGenerationDTO.java
@@ -1,0 +1,8 @@
+package br.com.notehub.adapter.consumer.dto;
+
+public record SecretKeyGenerationDTO(
+        String mailTo,
+        String subject,
+        String text
+) {
+}

--- a/src/main/java/br/com/notehub/adapter/producer/MailProducer.java
+++ b/src/main/java/br/com/notehub/adapter/producer/MailProducer.java
@@ -3,6 +3,7 @@ package br.com.notehub.adapter.producer;
 import br.com.notehub.adapter.producer.dto.ActivationDTO;
 import br.com.notehub.adapter.producer.dto.EmailChangeDTO;
 import br.com.notehub.adapter.producer.dto.PasswordChangeDTO;
+import br.com.notehub.adapter.producer.dto.SecretKeyGenerationDTO;
 import br.com.notehub.domain.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.amqp.rabbit.core.RabbitTemplate;
@@ -15,6 +16,9 @@ public class MailProducer {
 
     @Value("${broker.queue.activation.name}")
     private String activationRoutingKey;
+
+    @Value("${broker.queue.secret.name}")
+    private String secretRoutingKey;
 
     @Value("${broker.queue.password.name}")
     private String passwordRoutingKey;
@@ -30,6 +34,11 @@ public class MailProducer {
     public void publishAccountActivationMessage(String jwt, User user) {
         var message = new ActivationDTO(client, jwt, user);
         rabbitTemplate.convertAndSend("", activationRoutingKey, message);
+    }
+
+    public void publishAccountSecretKeyGenerationMessage(String mailTo, String secretKey) {
+        var message = SecretKeyGenerationDTO.of(mailTo, secretKey);
+        rabbitTemplate.convertAndSend("", secretRoutingKey, message);
     }
 
     public void publishAccountPasswordChangeMessage(String mailTo, String token) {

--- a/src/main/java/br/com/notehub/adapter/producer/dto/SecretKeyGenerationDTO.java
+++ b/src/main/java/br/com/notehub/adapter/producer/dto/SecretKeyGenerationDTO.java
@@ -1,0 +1,32 @@
+package br.com.notehub.adapter.producer.dto;
+
+import org.springframework.core.io.ClassPathResource;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public record SecretKeyGenerationDTO(
+        String mailTo,
+        String subject,
+        String text
+) {
+
+    public static String text(String secretKey) {
+        try {
+            ClassPathResource resource = new ClassPathResource("template/mail/secret-key.html");
+            String template = new String(resource.getInputStream().readAllBytes(), StandardCharsets.UTF_8);
+            return template.replace("{secret.key}", secretKey);
+        } catch (IOException exception) {
+            throw new ExceptionInInitializerError(exception);
+        }
+    }
+
+    public static SecretKeyGenerationDTO of(String mailTo, String secretKey) {
+        return new SecretKeyGenerationDTO(
+                mailTo,
+                "Chave Secreta",
+                text(secretKey)
+        );
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/controller/auth/AuthController.java
+++ b/src/main/java/br/com/notehub/application/controller/auth/AuthController.java
@@ -7,6 +7,7 @@ import br.com.notehub.application.dto.request.token.OAuth2GoogleREQ;
 import br.com.notehub.application.dto.request.token.OAuthGitHubREQ;
 import br.com.notehub.application.dto.response.token.AuthRES;
 import br.com.notehub.domain.token.TokenService;
+import br.com.notehub.domain.user.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -31,6 +32,7 @@ import org.springframework.web.bind.annotation.*;
 public class AuthController {
 
     private final TokenService service;
+    private final UserService userService;
     private final MailProducer producer;
 
     @Operation(summary = "Login user", description = "Authenticates a user with username and password.")
@@ -120,6 +122,23 @@ public class AuthController {
     ) {
         service.logout(request);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @Operation(summary = "Request secret key", description = "Generates a secret key for user deletion and sends it via email.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "202", description = "Email sent successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid input data.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "404", description = "Account not found.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
+    })
+    @PostMapping("/secret-key")
+    public ResponseEntity<Void> requestSecretKey(
+            @Valid @RequestBody AuthChangeREQ dto
+    ) {
+        String secretKey = service.generateSecretKey(dto.email());
+        userService.changePassword(dto.email(), secretKey);
+        producer.publishAccountSecretKeyGenerationMessage(dto.email(), secretKey);
+        return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     @Operation(summary = "Request user password change", description = "Generates a token for password change and sends it via email.")

--- a/src/main/java/br/com/notehub/application/controller/auth/AuthController.java
+++ b/src/main/java/br/com/notehub/application/controller/auth/AuthController.java
@@ -56,6 +56,7 @@ public class AuthController {
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User authenticated successfully."),
             @ApiResponse(responseCode = "400", description = "Missing or invalid X-Device-Id or Google token.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "406", description = "Email already exists.", content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
     })
     @Parameter(name = "X-Device-Id", in = ParameterIn.HEADER, required = true, schema = @Schema(format = "uuid"))
@@ -68,10 +69,11 @@ public class AuthController {
         return ResponseEntity.status(HttpStatus.OK).body(token);
     }
 
-    @Operation(summary = "Login with GitHub", description = "Authenticates a user using GitHub OAuth2 token.")
+    @Operation(summary = "Login with GitHub", description = "Authenticates a user using GitHub OAuth token.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User authenticated successfully."),
             @ApiResponse(responseCode = "400", description = "Missing or invalid X-Device-Id or input data.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "406", description = "Email already exists.", content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
     })
     @Parameter(name = "X-Device-Id", in = ParameterIn.HEADER, required = true, schema = @Schema(format = "uuid"))

--- a/src/main/java/br/com/notehub/application/dto/oauth/OAuthResponse.java
+++ b/src/main/java/br/com/notehub/application/dto/oauth/OAuthResponse.java
@@ -1,0 +1,35 @@
+package br.com.notehub.application.dto.oauth;
+
+import br.com.notehub.application.dto.oauth.github.EmailResponse;
+import br.com.notehub.application.dto.oauth.github.GitHubUserResponse;
+import br.com.notehub.application.dto.oauth.google.GoogleUserResponse;
+
+public record OAuthResponse(
+        String id,
+        String email,
+        String username,
+        String displayName,
+        String avatar
+) {
+
+    public OAuthResponse(GitHubUserResponse userResponse, EmailResponse emailResponse) {
+        this(
+                userResponse.id(),
+                emailResponse.email(),
+                userResponse.username(),
+                userResponse.displayName(),
+                userResponse.avatar()
+        );
+    }
+
+    public OAuthResponse(GoogleUserResponse userResponse) {
+        this(
+                userResponse.id(),
+                userResponse.email(),
+                userResponse.username(),
+                userResponse.displayName(),
+                userResponse.avatar()
+        );
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/dto/oauth/github/CodeResponse.java
+++ b/src/main/java/br/com/notehub/application/dto/oauth/github/CodeResponse.java
@@ -1,0 +1,11 @@
+package br.com.notehub.application.dto.oauth.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record CodeResponse(
+        @JsonProperty("access_token") String accessToken,
+        @JsonProperty("token_type") String tokenType
+) {
+}

--- a/src/main/java/br/com/notehub/application/dto/oauth/github/EmailResponse.java
+++ b/src/main/java/br/com/notehub/application/dto/oauth/github/EmailResponse.java
@@ -1,0 +1,13 @@
+package br.com.notehub.application.dto.oauth.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record EmailResponse(
+        @JsonProperty("email") String email,
+        @JsonProperty("primary") Boolean primary,
+        @JsonProperty("verified") Boolean verified,
+        @JsonProperty("visibility") String visibility
+) {
+}

--- a/src/main/java/br/com/notehub/application/dto/oauth/github/GitHubUserResponse.java
+++ b/src/main/java/br/com/notehub/application/dto/oauth/github/GitHubUserResponse.java
@@ -1,0 +1,13 @@
+package br.com.notehub.application.dto.oauth.github;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GitHubUserResponse(
+        @JsonProperty("id") String id,
+        @JsonProperty("login") String username,
+        @JsonProperty("name") String displayName,
+        @JsonProperty("avatar_url") String avatar
+) {
+}

--- a/src/main/java/br/com/notehub/application/dto/oauth/google/GoogleUserResponse.java
+++ b/src/main/java/br/com/notehub/application/dto/oauth/google/GoogleUserResponse.java
@@ -1,0 +1,14 @@
+package br.com.notehub.application.dto.oauth.google;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record GoogleUserResponse(
+        @JsonProperty("id") String id,
+        @JsonProperty("email") String email,
+        @JsonProperty("given_name") String username,
+        @JsonProperty("name") String displayName,
+        @JsonProperty("picture") String avatar
+) {
+}

--- a/src/main/java/br/com/notehub/application/dto/response/user/CreateUserRES.java
+++ b/src/main/java/br/com/notehub/application/dto/response/user/CreateUserRES.java
@@ -1,5 +1,6 @@
 package br.com.notehub.application.dto.response.user;
 
+import br.com.notehub.domain.user.Host;
 import br.com.notehub.domain.user.User;
 
 import java.util.UUID;
@@ -9,7 +10,7 @@ public record CreateUserRES(
         String email,
         String username,
         String display_name,
-        String host,
+        Host host,
         boolean profile_private,
         boolean sponsor,
         Long score

--- a/src/main/java/br/com/notehub/application/dto/response/user/PersonalUserRES.java
+++ b/src/main/java/br/com/notehub/application/dto/response/user/PersonalUserRES.java
@@ -1,5 +1,7 @@
 package br.com.notehub.application.dto.response.user;
 
+import br.com.notehub.domain.user.Host;
+
 import java.util.UUID;
 
 public record PersonalUserRES(
@@ -11,7 +13,7 @@ public record PersonalUserRES(
         String avatar,
         String banner,
         String message,
-        String host,
+        Host host,
         boolean profile_private,
         boolean sponsor,
         Long score,

--- a/src/main/java/br/com/notehub/application/implementation/token/TokenServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/token/TokenServiceImpl.java
@@ -1,38 +1,35 @@
 package br.com.notehub.application.implementation.token;
 
+import br.com.notehub.application.dto.oauth.OAuthResponse;
 import br.com.notehub.application.dto.response.token.AuthRES;
+import br.com.notehub.application.oauth.OAuthFacade;
 import br.com.notehub.domain.token.Token;
 import br.com.notehub.domain.token.TokenRepository;
 import br.com.notehub.domain.token.TokenService;
+import br.com.notehub.domain.user.Host;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserRepository;
 import br.com.notehub.infra.exception.CustomExceptions;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTCreationException;
-import com.auth0.jwt.exceptions.JWTDecodeException;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.exceptions.TokenExpiredException;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.DisabledException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
 
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 
@@ -43,12 +40,7 @@ public class TokenServiceImpl implements TokenService {
     @Value("${api.server.security.token.secret}")
     private String secret;
 
-    @Value("${oauth.github.client.id}")
-    private String GHCI;
-
-    @Value("${oauth.github.client.secret}")
-    private String GHCS;
-
+    private final OAuthFacade oAuthFacade;
     private final TokenRepository repository;
     private final UserRepository userRepository;
     private final PasswordEncoder encoder;
@@ -83,39 +75,17 @@ public class TokenServiceImpl implements TokenService {
         return new Token(user, ip, agent, device, expiresAt);
     }
 
-    private Map getUserInfoFromGoogle(String token) {
-        String url = String.format("https://www.googleapis.com/oauth2/v1/userinfo?access_token=%s", token);
-        ResponseEntity<Map> response = new RestTemplate().getForEntity(url, Map.class);
-        if (response.getStatusCode().is2xxSuccessful() && response.getBody() != null) {
-            System.out.println(response.getBody());
-            return response.getBody();
-        } else {
-            throw new JWTDecodeException("Token inválido");
-        }
+    private void validateHost(Host host) {
+        if (!Objects.equals(host, Host.NOTEHUB)) throw new CustomExceptions.HostNotAllowedException();
     }
 
-    private Map getUserInfoFromGitHub(String code) {
-        RestTemplate rt = new RestTemplate();
-        ResponseEntity<Map> fResponse = rt.getForEntity(
-                String.format("https://github.com/login/oauth/access_token?client_id=%s&client_secret=%s&code=%s", GHCI, GHCS, code),
-                Map.class
-        );
-        if (!fResponse.getStatusCode().is2xxSuccessful() || fResponse.getBody() == null) throw new JWTDecodeException("Código inválido");
-        ResponseEntity<Map> sResponse = rt.exchange(
-                "https://api.github.com/user",
-                HttpMethod.GET,
-                new HttpEntity<>(new HttpHeaders() {{
-                    setBearerAuth((String) fResponse.getBody().get("access_token"));
-                    set("Accept", "application/json");
-                }}),
-                Map.class
-        );
-        if (!sResponse.getStatusCode().is2xxSuccessful() || sResponse.getBody() == null) throw new JWTDecodeException("Token inválido");
-        return sResponse.getBody();
-    }
-
-    private void validateHost(String host) {
-        if (!Objects.equals(host, "NoteHub")) throw new CustomExceptions.HostNotAllowedException();
+    private User findOrCreateUserFromOAuthInfo(OAuthResponse info, Host host) {
+        return userRepository.findByProviderId(info.id()).orElseGet(() -> {
+            if (userRepository.existsByEmail(info.email())) throw new DataIntegrityViolationException("email");
+            String username = oAuthFacade.resolveUniqueUsername(info.id(), info.username());
+            User provided = new User(info.id(), host, info.email(), username, info.displayName(), info.avatar());
+            return userRepository.save(provided);
+        });
     }
 
     @Override
@@ -221,47 +191,23 @@ public class TokenServiceImpl implements TokenService {
     @Transactional
     @Override
     public AuthRES authWithGoogleAcc(HttpServletRequest request, String token) {
-        try {
-
-            Map info = getUserInfoFromGoogle(token);
-            String id = (String) info.get("id");
-            String email = (String) info.get("email");
-            String givenName = (String) info.get("given_name");
-            String displayName = (String) info.get("name");
-            String username = String.format("%s%s", givenName, id.substring(0, 4));
-            String avatar = (String) info.get("picture");
-            User provided = new User(id, email, username, displayName, avatar);
-
-            User user = userRepository.findByProviderId(id).orElseGet(() -> userRepository.save(provided));
-            Token rToken = generateRefreshToken(request, user);
-            repository.findByDevice(rToken.getDevice()).ifPresent(repository::delete);
-            repository.save(rToken);
-
-            return new AuthRES(rToken, generateToken(user));
-
-        } catch (JWTDecodeException exception) {
-            throw new JWTDecodeException("Formato inválido");
-        }
+        OAuthResponse info = oAuthFacade.getGoogleUser(token);
+        User user = findOrCreateUserFromOAuthInfo(info, Host.GOOGLE);
+        Token rToken = generateRefreshToken(request, user);
+        repository.findByDevice(rToken.getDevice()).ifPresent(repository::delete);
+        repository.save(rToken);
+        return new AuthRES(rToken, generateToken(user));
     }
 
     @Transactional
     @Override
     public AuthRES authWithGitHubAcc(HttpServletRequest request, String code) {
-        Map info = getUserInfoFromGitHub(code);
-        Integer id = (Integer) info.get("id");
-        String login = (String) info.get("login");
-        String username = String.format("%s%s", login, id.toString().substring(0, 4));
-        String displayName = (String) info.get("name");
-        String avatar = (String) info.get("avatar_url");
-        User provided = new User(id, username, displayName, avatar);
-
-        User user = userRepository.findByProviderId(id.toString()).orElseGet(() -> userRepository.save(provided));
+        OAuthResponse info = oAuthFacade.getGitHubUser(code);
+        User user = findOrCreateUserFromOAuthInfo(info, Host.GITHUB);
         Token token = generateRefreshToken(request, user);
         repository.findByDevice(token.getDevice()).ifPresent(repository::delete);
         repository.save(token);
-
         return new AuthRES(token, generateToken(user));
-
     }
 
     @Transactional

--- a/src/main/java/br/com/notehub/application/implementation/token/TokenServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/token/TokenServiceImpl.java
@@ -81,7 +81,7 @@ public class TokenServiceImpl implements TokenService {
         if (Objects.equals(host, Host.NOTEHUB)) throw new CustomExceptions.HostNotAllowedException();
     }
 
-    private void validateHost(Host host) {
+    private void validateExternalHost(Host host) {
         if (!Objects.equals(host, Host.NOTEHUB)) throw new CustomExceptions.HostNotAllowedException();
     }
 
@@ -133,12 +133,13 @@ public class TokenServiceImpl implements TokenService {
     @Override
     public String generatePasswordChangeToken(String email) {
         User user = userRepository.findByEmail(email).orElseThrow(EntityNotFoundException::new);
-        validateHost(user.getHost());
+        validateExternalHost(user.getHost());
         try {
             Algorithm algorithm = Algorithm.HMAC256(secret);
             return JWT.create()
                     .withIssuer("NoteHub")
                     .withSubject(email)
+                    .withClaim("scope", "password")
                     .withExpiresAt(getExpirationTime("access"))
                     .sign(algorithm);
         } catch (JWTCreationException exception) {
@@ -148,13 +149,12 @@ public class TokenServiceImpl implements TokenService {
 
     @Override
     public String generateEmailChangeToken(String email) {
-        User user = userRepository.findByEmail(email).orElseThrow(EntityNotFoundException::new);
-        validateHost(user.getHost());
         try {
             Algorithm algorithm = Algorithm.HMAC256(secret);
             return JWT.create()
                     .withIssuer("NoteHub")
                     .withSubject(email)
+                    .withClaim("scope", "email")
                     .withExpiresAt(getExpirationTime("access"))
                     .sign(algorithm);
         } catch (JWTCreationException exception) {

--- a/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
@@ -24,7 +24,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.net.UnknownHostException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.List;
@@ -50,9 +49,6 @@ public class UserServiceImpl implements UserService {
     @SneakyThrows
     private <T> void changeField(UUID idFromToken, String field, Function<User, T> getter, Consumer<User> setter) {
         User user = repository.findById(idFromToken).orElseThrow(EntityNotFoundException::new);
-        if (!Objects.equals(user.getHost(), Host.NOTEHUB) && (Objects.equals(field, "email") | Objects.equals(field, "password"))) {
-            throw new UnknownHostException("Host não autorizado.");
-        }
         T oldValue = getter.apply(user);
         setter.accept(user);
         T newValue = getter.apply(user);
@@ -145,7 +141,6 @@ public class UserServiceImpl implements UserService {
     @Override
     public void changePassword(String email, String newPassword) {
         User entity = repository.findByEmail(email).orElseThrow(EntityNotFoundException::new);
-        validateHost(entity.getHost());
         String password = validatePassword(entity.getPassword(), newPassword);
         changeField(entity.getId(), "password", User::getPassword, user -> user.setPassword(password));
     }

--- a/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
@@ -6,6 +6,7 @@ import br.com.notehub.domain.history.UserHistoryService;
 import br.com.notehub.domain.note.NoteService;
 import br.com.notehub.domain.notification.NotificationService;
 import br.com.notehub.domain.token.TokenService;
+import br.com.notehub.domain.user.Host;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserRepository;
 import br.com.notehub.domain.user.UserService;
@@ -49,7 +50,7 @@ public class UserServiceImpl implements UserService {
     @SneakyThrows
     private <T> void changeField(UUID idFromToken, String field, Function<User, T> getter, Consumer<User> setter) {
         User user = repository.findById(idFromToken).orElseThrow(EntityNotFoundException::new);
-        if (!Objects.equals(user.getHost(), "NoteHub") && (Objects.equals(field, "email") | Objects.equals(field, "password"))) {
+        if (!Objects.equals(user.getHost(), Host.NOTEHUB) && (Objects.equals(field, "email") | Objects.equals(field, "password"))) {
             throw new UnknownHostException("Host não autorizado.");
         }
         T oldValue = getter.apply(user);
@@ -60,8 +61,8 @@ public class UserServiceImpl implements UserService {
         historian.setHistory(user, field, String.valueOf(oldValue), newValue.toString());
     }
 
-    private void validateHost(String host) {
-        if (!Objects.equals(host, "NoteHub")) throw new CustomExceptions.HostNotAllowedException();
+    private void validateHost(Host host) {
+        if (!Objects.equals(host, Host.NOTEHUB)) throw new CustomExceptions.HostNotAllowedException();
     }
 
     private String validatePassword(String oldPassword, String newPassword) {

--- a/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
@@ -6,7 +6,6 @@ import br.com.notehub.domain.history.UserHistoryService;
 import br.com.notehub.domain.note.NoteService;
 import br.com.notehub.domain.notification.NotificationService;
 import br.com.notehub.domain.token.TokenService;
-import br.com.notehub.domain.user.Host;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserRepository;
 import br.com.notehub.domain.user.UserService;
@@ -55,10 +54,6 @@ public class UserServiceImpl implements UserService {
         if (Objects.equals(oldValue, newValue)) return;
         repository.save(user);
         historian.setHistory(user, field, String.valueOf(oldValue), newValue.toString());
-    }
-
-    private void validateHost(Host host) {
-        if (!Objects.equals(host, Host.NOTEHUB)) throw new CustomExceptions.HostNotAllowedException();
     }
 
     private String validatePassword(String oldPassword, String newPassword) {
@@ -150,7 +145,6 @@ public class UserServiceImpl implements UserService {
     public void changeEmail(String oldEmail, String newEmail) {
         validateEmail(oldEmail, newEmail);
         User entity = repository.findByEmail(oldEmail).orElseThrow(EntityNotFoundException::new);
-        validateHost(entity.getHost());
         changeField(entity.getId(), "email", User::getEmail, user -> user.setEmail(newEmail.toLowerCase()));
     }
 

--- a/src/main/java/br/com/notehub/application/oauth/OAuthFacade.java
+++ b/src/main/java/br/com/notehub/application/oauth/OAuthFacade.java
@@ -1,0 +1,39 @@
+package br.com.notehub.application.oauth;
+
+import br.com.notehub.application.dto.oauth.OAuthResponse;
+import br.com.notehub.application.oauth.github.OAuthGitHubService;
+import br.com.notehub.application.oauth.google.OAuthGoogleService;
+import br.com.notehub.domain.user.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.Random;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthFacade {
+
+    private final UserRepository userRepository;
+    private final OAuthGitHubService gitHubService;
+    private final OAuthGoogleService googleService;
+
+    public String resolveUniqueUsername(String id, String base) {
+        int attempt = 0;
+        String username = base.toLowerCase();
+        while (attempt < 12 && userRepository.existsByUsername(username)) {
+            username = base.toLowerCase() + (new Random().nextInt(9000) + 1000);
+            attempt++;
+        }
+        if (userRepository.existsByUsername(username)) username = base + id.substring(0, 4);
+        return username;
+    }
+
+    public OAuthResponse getGitHubUser(String code) {
+        return gitHubService.getUser(code);
+    }
+
+    public OAuthResponse getGoogleUser(String token) {
+        return googleService.getUser(token);
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/oauth/OAuthService.java
+++ b/src/main/java/br/com/notehub/application/oauth/OAuthService.java
@@ -1,0 +1,11 @@
+package br.com.notehub.application.oauth;
+
+import br.com.notehub.application.dto.oauth.OAuthResponse;
+import org.springframework.stereotype.Service;
+
+@Service
+public interface OAuthService {
+
+    OAuthResponse getUser(String key);
+
+}

--- a/src/main/java/br/com/notehub/application/oauth/github/OAuthGitHubService.java
+++ b/src/main/java/br/com/notehub/application/oauth/github/OAuthGitHubService.java
@@ -1,0 +1,90 @@
+package br.com.notehub.application.oauth.github;
+
+import br.com.notehub.application.dto.oauth.OAuthResponse;
+import br.com.notehub.application.dto.oauth.github.CodeResponse;
+import br.com.notehub.application.dto.oauth.github.EmailResponse;
+import br.com.notehub.application.dto.oauth.github.GitHubUserResponse;
+import br.com.notehub.application.oauth.OAuthService;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.List;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthGitHubService implements OAuthService {
+
+    @Value("${oauth.github.client.id}")
+    private String GHCI;
+
+    @Value("${oauth.github.client.secret}")
+    private String GHCS;
+
+    private final HttpClient client = HttpClient.newHttpClient();
+    private final ObjectMapper mapper;
+
+    @Override
+    public OAuthResponse getUser(String key) {
+
+        try {
+
+            HttpRequest codeRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(String.format(
+                            "https://github.com/login/oauth/access_token?client_id=%s&client_secret=%s&code=%s",
+                            GHCI, GHCS, key)))
+                    .header("Accept", "application/json")
+                    .build();
+            HttpResponse<String> codeResponse = client.send(codeRequest, HttpResponse.BodyHandlers.ofString());
+            CodeResponse codeData = mapper.readValue(codeResponse.body(), CodeResponse.class);
+
+            HttpRequest userRequest = HttpRequest.newBuilder()
+                    .uri(URI.create("https://api.github.com/user"))
+                    .headers(
+                            "Accept", "application/json",
+                            "Authorization", "Bearer " + codeData.accessToken()
+                    )
+                    .build();
+            HttpResponse<String> userResponse = client.send(userRequest, HttpResponse.BodyHandlers.ofString());
+            GitHubUserResponse userData = mapper.readValue(userResponse.body(), GitHubUserResponse.class);
+
+            HttpRequest emailsRequest = HttpRequest.newBuilder()
+                    .uri(URI.create("https://api.github.com/user/emails"))
+                    .headers(
+                            "Accept", "application/json",
+                            "Authorization", "Bearer " + codeData.accessToken()
+                    )
+                    .build();
+            HttpResponse<String> emailsResponse = client.send(emailsRequest, HttpResponse.BodyHandlers.ofString());
+
+            List<EmailResponse> emailsData = mapper.readValue(
+                    emailsResponse.body(),
+                    new TypeReference<List<EmailResponse>>() {
+                    }
+            );
+
+            Optional<EmailResponse> opt = emailsData.stream().filter(e -> e.primary() && e.verified()).findFirst();
+            if (opt.isEmpty()) opt = emailsData.stream().filter(e -> Boolean.TRUE.equals(e.primary())).findFirst();
+            if (opt.isEmpty()) opt = emailsData.stream().filter(e -> Boolean.TRUE.equals(e.verified())).findFirst();
+
+            EmailResponse emailData = opt.orElseGet(() -> emailsData.isEmpty() ? null : emailsData.getFirst());
+
+            if (emailData == null) throw new JWTDecodeException("Email faltando.");
+
+            return new OAuthResponse(userData, emailData);
+
+        } catch (Exception e) {
+            throw new JWTDecodeException("Código inválido.");
+        }
+
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/oauth/google/OAuthGoogleService.java
+++ b/src/main/java/br/com/notehub/application/oauth/google/OAuthGoogleService.java
@@ -1,0 +1,38 @@
+package br.com.notehub.application.oauth.google;
+
+import br.com.notehub.application.dto.oauth.OAuthResponse;
+import br.com.notehub.application.dto.oauth.google.GoogleUserResponse;
+import br.com.notehub.application.oauth.OAuthService;
+import com.auth0.jwt.exceptions.JWTDecodeException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+
+@Component
+@RequiredArgsConstructor
+public class OAuthGoogleService implements OAuthService {
+
+    private final HttpClient client = HttpClient.newHttpClient();
+    private final ObjectMapper mapper;
+
+    @Override
+    public OAuthResponse getUser(String token) {
+        try {
+            HttpRequest codeRequest = HttpRequest.newBuilder()
+                    .uri(URI.create("https://www.googleapis.com/oauth2/v1/userinfo"))
+                    .headers("Accept", "application/json", "Authorization", "Bearer " + token)
+                    .build();
+            HttpResponse<String> tokenResponse = client.send(codeRequest, HttpResponse.BodyHandlers.ofString());
+            GoogleUserResponse userData = mapper.readValue(tokenResponse.body(), GoogleUserResponse.class);
+            return new OAuthResponse(userData);
+        } catch (Exception e) {
+            throw new JWTDecodeException("Token inválido.");
+        }
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/token/TokenService.java
+++ b/src/main/java/br/com/notehub/domain/token/TokenService.java
@@ -22,6 +22,8 @@ public interface TokenService {
 
     String generateEmailChangeToken(String email);
 
+    String generateSecretKey(String email);
+
     String validateToken(String accessToken);
 
     AuthRES auth(HttpServletRequest request, String username, String password) throws BadCredentialsException;

--- a/src/main/java/br/com/notehub/domain/user/Host.java
+++ b/src/main/java/br/com/notehub/domain/user/Host.java
@@ -1,0 +1,24 @@
+package br.com.notehub.domain.user;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
+public enum Host {
+
+    NOTEHUB("NoteHub"),
+    GOOGLE("Google"),
+    GITHUB("GitHub");
+
+    private final String host;
+
+    Host(String host) {
+        this.host = host;
+    }
+
+    @JsonValue
+    public String getHost() {
+        return host;
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/user/HostConverter.java
+++ b/src/main/java/br/com/notehub/domain/user/HostConverter.java
@@ -1,0 +1,25 @@
+package br.com.notehub.domain.user;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class HostConverter implements AttributeConverter<Host, String> {
+
+    @Override
+    public String convertToDatabaseColumn(Host host) {
+        return host.getHost();
+    }
+
+    @Override
+    public Host convertToEntityAttribute(String host) {
+        if (host == null) return null;
+        for (Host h : Host.values()) {
+            if (h.getHost().equals(host)) {
+                return h;
+            }
+        }
+        throw new IllegalArgumentException("Unknown value: " + host);
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/user/User.java
+++ b/src/main/java/br/com/notehub/domain/user/User.java
@@ -56,7 +56,8 @@ public class User implements UserDetails {
 
     private String password;
 
-    private String host;
+    @Convert(converter = HostConverter.class)
+    private Host host;
 
     private boolean profilePrivate = false;
 
@@ -110,7 +111,7 @@ public class User implements UserDetails {
     private int followersCount = 0;
 
     public User(String email, String username, String displayName, String password) {
-        this.host = "NoteHub";
+        this.host = Host.NOTEHUB;
         this.email = email;
         this.displayName = displayName;
         this.username = username;
@@ -118,19 +119,10 @@ public class User implements UserDetails {
         this.active = false;
     }
 
-    public User(String id, String email, String username, String displayName, String avatar) {
+    public User(String id, Host host, String email, String username, String displayName, String avatar) {
         this.providerId = id;
-        this.host = "Google";
+        this.host = host;
         this.email = email;
-        this.username = username.toLowerCase();
-        this.displayName = displayName;
-        this.avatar = avatar;
-        this.active = true;
-    }
-
-    public User(Integer id, String username, String displayName, String avatar) {
-        this.providerId = id.toString();
-        this.host = "GitHub";
         this.username = username.toLowerCase();
         this.displayName = displayName;
         this.avatar = avatar;

--- a/src/main/java/br/com/notehub/infra/exception/ControllerAdvice.java
+++ b/src/main/java/br/com/notehub/infra/exception/ControllerAdvice.java
@@ -182,6 +182,13 @@ public class ControllerAdvice {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errors.stream().map(CustomResponse::new).toList());
     }
 
+    @ExceptionHandler(CustomExceptions.ScopeNotAllowedException.class)
+    private ResponseEntity<List<CustomResponse>> handleScopeNotAllowedException(CustomExceptions.ScopeNotAllowedException ex) {
+        List<FieldError> errors = new ArrayList<>();
+        errors.add(new FieldError("token", "scope", ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.FORBIDDEN).body(errors.stream().map(CustomResponse::new).toList());
+    }
+
     @ExceptionHandler(CustomExceptions.SamePasswordException.class)
     private ResponseEntity<List<CustomResponse>> handleSamePasswordException(CustomExceptions.SamePasswordException ex) {
         List<FieldError> errors = new ArrayList<>();

--- a/src/main/java/br/com/notehub/infra/exception/CustomExceptions.java
+++ b/src/main/java/br/com/notehub/infra/exception/CustomExceptions.java
@@ -34,6 +34,12 @@ public class CustomExceptions {
         }
     }
 
+    public static class ScopeNotAllowedException extends BusinessException {
+        public ScopeNotAllowedException() {
+            super("Escopo não autorizado.");
+        }
+    }
+
     public static class SamePasswordException extends BusinessException {
         public SamePasswordException() {
             super("Senha atual.");

--- a/src/main/java/br/com/notehub/infra/messaging/RabbitMQConfig.java
+++ b/src/main/java/br/com/notehub/infra/messaging/RabbitMQConfig.java
@@ -13,6 +13,9 @@ public class RabbitMQConfig {
     @Value("${broker.queue.activation.name}")
     private String activation;
 
+    @Value("${broker.queue.secret.name}")
+    private String secret;
+
     @Value("${broker.queue.password.name}")
     private String password;
 
@@ -22,6 +25,11 @@ public class RabbitMQConfig {
     @Bean
     public Queue activationQueue() {
         return new Queue(activation, true);
+    }
+
+    @Bean
+    public Queue secretQueue() {
+        return new Queue(secret, true);
     }
 
     @Bean

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -27,6 +27,7 @@ oauth.github.client.secret=${GHCS}
 
 spring.rabbitmq.addresses=${RABBITMQ_ADDRESSES}
 broker.queue.activation.name=default.activation
+broker.queue.secret.name=default.secret
 broker.queue.password.name=default.password
 broker.queue.email.name=default.email
 

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -15,6 +15,7 @@ oauth.github.client.secret=${GHCS}
 
 spring.rabbitmq.addresses=${RABBITMQ_ADDRESSES}
 broker.queue.activation.name=default.activation
+broker.queue.secret.name=default.secret
 broker.queue.password.name=default.password
 broker.queue.email.name=default.email
 

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -33,5 +33,6 @@ spring.mail.password=
 
 spring.rabbitmq.addresses=amqp://user:root@rabbitmq:5672
 broker.queue.activation.name=default.activation
+broker.queue.secret.name=default.secret
 broker.queue.password.name=default.password
 broker.queue.email.name=default.email

--- a/src/main/resources/template/mail/secret-key.html
+++ b/src/main/resources/template/mail/secret-key.html
@@ -1,0 +1,266 @@
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="content-type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0;">
+    <meta name="format-detection" content="telephone=no"/>
+
+    <style>
+        /* Reset styles */
+        body { margin: 0; padding: 0; min-width: 100%; width: 100% !important; height: 100% !important;}
+        body, table, td, div, p, a { -webkit-font-smoothing: antialiased; text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; line-height: 100%; }
+        table, td { mso-table-lspace: 0pt; mso-table-rspace: 0pt; border-collapse: collapse !important; border-spacing: 0; }
+        img { border: 0; line-height: 100%; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; }
+        #outlook a { padding: 0; }
+        .ReadMsgBody { width: 100%; } .ExternalClass { width: 100%; }
+        .ExternalClass, .ExternalClass p, .ExternalClass span, .ExternalClass font, .ExternalClass td, .ExternalClass div { line-height: 100%; }
+
+        /* Rounded corners for advanced mail clients only */
+        @media all and (min-width: 560px) {
+            .container { border-radius: 8px; -webkit-border-radius: 8px; -moz-border-radius: 8px; -khtml-border-radius: 8px;}
+        }
+
+        /* Set color for auto links (addresses, dates, etc.) */
+        a, a:hover {
+            color: #127DB3;
+        }
+        .footer a, .footer a:hover {
+            color: #999999;
+        }
+
+    </style>
+
+    <!-- MESSAGE SUBJECT -->
+    <title>Redefina a sua senha</title>
+
+</head>
+
+<!-- BODY -->
+<!-- Set message background color (twice) and text color (twice) -->
+<body topmargin="0" rightmargin="0" bottommargin="0" leftmargin="0" marginwidth="0" marginheight="0" width="100%" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%; height: 100%; -webkit-font-smoothing: antialiased; text-size-adjust: 100%; -ms-text-size-adjust: 100%; -webkit-text-size-adjust: 100%; line-height: 100%;
+	background-color: #F0F0F0;
+	color: #000000;"
+      bgcolor="#F0F0F0"
+      text="#000000">
+
+<!-- SECTION / BACKGROUND -->
+<!-- Set message background color one again -->
+<table width="100%" align="center" border="0" cellpadding="0" cellspacing="0" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; width: 100%;"
+       class="background">
+    <tr>
+        <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0;"
+            bgcolor="#F0F0F0">
+
+            <!-- WRAPPER -->
+            <!-- Set wrapper width (twice) -->
+            <table border="0" cellpadding="0" cellspacing="0" align="center"
+                   width="560" style="border-collapse: collapse; border-spacing: 0; padding: 0; width: inherit;
+	max-width: 560px;" class="wrapper">
+
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;
+			padding-top: 20px;
+			padding-bottom: 20px;">
+
+                        <!-- LOGO -->
+                        <!-- Image text color should be opposite to background color. Set your url, image src, alt and title. Alt text should fit the image size. Real image size should be x2. URL format: http://domain.com/?utm_source={{Campaign-Source}}&utm_medium=email&utm_content=logo&utm_campaign={{Campaign-Name}} -->
+                        <a target="_blank" style="text-decoration: none;"
+                           href="{api.client.host}"><img border="0" vspace="0" hspace="0"
+                                                         src="https://raw.githubusercontent.com/lucas-adm/springboot-notehub/refs/heads/main/src/main/resources/public/imgs/logo.png"
+                                                         width="20%" height="20%"
+                                                         style="
+				color: #000000;
+				font-size: 10px; margin: 0; padding: 0; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; border: none; display: block;"/></a>
+
+                    </td>
+                </tr>
+
+                <!-- End of WRAPPER -->
+            </table>
+
+            <!-- WRAPPER / CONTEINER -->
+            <!-- Set conteiner background color -->
+            <table border="0" cellpadding="0" cellspacing="0" align="center"
+                   bgcolor="#FFFFFF"
+                   width="560" style="border-collapse: collapse; border-spacing: 0; padding: 0; width: inherit;
+	max-width: 560px;" class="container">
+
+                <!-- HEADER -->
+                <!-- Set text color and font family ("sans-serif" or "Georgia, serif") -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 24px; font-weight: bold; line-height: 130%;
+			padding-top: 25px;
+			color: #000000;
+			font-family: sans-serif;" class="header">
+                        Chave Secreta
+                    </td>
+                </tr>
+
+                <!-- PARAGRAPH -->
+                <!-- Set text color and font family ("sans-serif" or "Georgia, serif"). Duplicate all text styles in links, including line-height -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 17px; font-weight: 400; line-height: 160%;
+			padding-top: 25px;
+			color: #000000;
+			font-family: sans-serif;" class="paragraph">
+                        Utilize esta chave como senha
+                    </td>
+                </tr>
+
+                <!-- BUTTON -->
+                <!-- Set button background color at TD, link/text color at A and TD, font family ("sans-serif" or "Georgia, serif") at TD. For verification codes add "letter-spacing: 5px;". Link format: http://domain.com/?utm_source={{Campaign-Source}}&utm_medium=email&utm_content={{Button-Name}}&utm_campaign={{Campaign-Name}} -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;
+			padding-top: 25px;
+			padding-bottom: 5px;" class="button">
+                        <div
+                                style="text-decoration: underline;">
+                            <table border="0" cellpadding="0" cellspacing="0" align="center"
+                                   style="max-width: 240px; min-width: 120px; border-collapse: collapse; border-spacing: 0; padding: 0;">
+                                <tr>
+                                    <td align="center" valign="middle"
+                                        style="max-width: 555px; word-break: break-word; padding: 12px 24px; margin: 0; border: solid #E0E0E0 2px; border-collapse: collapse; border-spacing: 0; border-radius: 4px; -webkit-border-radius: 4px; -moz-border-radius: 4px; -khtml-border-radius: 4px;"
+                                        bgcolor="#FFFFFF">
+                                        <p
+                                                style="color: #7c3aed; font-family: sans-serif; font-size: 18px; font-weight: 400; line-height: 120%;"
+                                        >
+                                            {secret.key}
+                                        </p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </td>
+                </tr>
+
+                <!-- LINE -->
+                <!-- Set line color -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;
+			padding-top: 25px;" class="line">
+                        <hr
+                                color="#E0E0E0" align="center" width="100%" size="1" noshade style="margin: 0; padding: 0;"/>
+                    </td>
+                </tr>
+
+                <!-- LIST -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%;"
+                        class="list-item">
+                        <table align="center" border="0" cellspacing="0" cellpadding="0"
+                               style="width: inherit; margin: 0; padding: 0; border-collapse: collapse; border-spacing: 0;">
+
+                            <!-- LIST ITEM -->
+                            <tr>
+
+                                <!-- LIST ITEM IMAGE -->
+                                <!-- Image text color should be opposite to background color. Set your url, image src, alt and title. Alt text should fit the image size. Real image size should be x2 -->
+                                <td align="left" valign="top" style="border-collapse: collapse; border-spacing: 0;
+					padding-top: 30px;
+					padding-right: 20px;"><img
+                                        border="0" vspace="0" hspace="0" style="padding: 0; margin: 0; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; border: none; display: block;
+					color: #000000;"
+                                        src="https://raw.githubusercontent.com/lucas-adm/springboot-notehub/refs/heads/main/src/main/resources/public/imgs/zhonya.png"
+                                        alt="Ampulheta" title="Ampulheta"
+                                        width="40" height="40"></td>
+
+                                <!-- LIST ITEM TEXT -->
+                                <!-- Set text color and font family ("sans-serif" or "Georgia, serif"). Duplicate all text styles in links, including line-height -->
+                                <td align="left" valign="top" style="font-size: 17px; font-weight: 400; line-height: 160%; border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0;
+					padding-top: 25px;
+					color: #000000;
+					font-family: sans-serif;" class="paragraph">
+                                    <b style="color: #7c3aed;">Tempo</b><br/>
+                                    A chave secreta tem tempo útil indefinido, tornando-se inválida apenas quando uma segunda chave é gerada.
+                                </td>
+
+                            </tr>
+
+                        </table>
+                    </td>
+                </tr>
+
+                <!-- LINE -->
+                <!-- Set line color -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;
+			padding-top: 25px;" class="line">
+                        <hr
+                                color="#E0E0E0" align="center" width="100%" size="1" noshade style="margin: 0; padding: 0;"/>
+                    </td>
+                </tr>
+
+                <!-- PARAGRAPH -->
+                <!-- Set text color and font family ("sans-serif" or "Georgia, serif"). Duplicate all text styles in links, including line-height -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 17px; font-weight: 400; line-height: 160%;
+			padding-top: 20px;
+			padding-bottom: 25px;
+			color: #000000;
+			font-family: sans-serif;" class="paragraph">
+                        Alguma&nbsp;dúvida? <a href="mailto:suporte@notehub.com.br" target="_blank"
+                                               style="color: #127DB3; font-family: sans-serif; font-size: 17px; font-weight: 400; line-height: 160%;">suporte@notehub.com.br</a>
+                    </td>
+                </tr>
+
+                <!-- End of WRAPPER -->
+            </table>
+
+            <!-- WRAPPER -->
+            <!-- Set wrapper width (twice) -->
+            <table border="0" cellpadding="0" cellspacing="0" align="center"
+                   width="560" style="border-collapse: collapse; border-spacing: 0; padding: 0; width: inherit;
+	max-width: 560px;" class="wrapper">
+
+                <!-- SOCIAL NETWORKS -->
+                <!-- Image text color should be opposite to background color. Set your url, image src, alt and title. Alt text should fit the image size. Real image size should be x2 -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%;
+			padding-top: 25px;" class="social-icons">
+                        <table
+                                width="256" border="0" cellpadding="0" cellspacing="0" align="center" style="border-collapse: collapse; border-spacing: 0; padding: 0;">
+                            <tr>
+
+                                <!-- ICON 1 -->
+                                <td align="center" valign="middle"
+                                    style="margin: 0; padding: 0; padding-left: 10px; padding-right: 10px; border-collapse: collapse; border-spacing: 0;">
+                                    <a target="_blank"
+                                       href="https://github.com/notehubbr/notehub-api"
+                                       style="text-decoration: none;"><img
+                                            border="0" vspace="0" hspace="0" style="padding: 0; margin: 0; outline: none; text-decoration: none; -ms-interpolation-mode: bicubic; border: none; display: inline-block;
+					color: #000000;"
+                                            alt="GitHub" title="Repository"
+                                            width="33" height="33"
+                                            src="https://raw.githubusercontent.com/lucas-adm/springboot-notehub/refs/heads/main/src/main/resources/public/imgs/github.png"></a>
+                                </td>
+                            </tr>
+                        </table>
+                    </td>
+                </tr>
+
+                <!-- FOOTER -->
+                <!-- Set text color and font family ("sans-serif" or "Georgia, serif"). Duplicate all text styles in links, including line-height -->
+                <tr>
+                    <td align="center" valign="top" style="border-collapse: collapse; border-spacing: 0; margin: 0; padding: 0; padding-left: 6.25%; padding-right: 6.25%; width: 87.5%; font-size: 13px; font-weight: 400; line-height: 150%;
+			padding-top: 20px;
+			padding-bottom: 20px;
+			color: #999999;
+			font-family: sans-serif;" class="footer">
+                        Somos parte da iniciativa open source, todo o
+                        <a href="https://github.com/notehubbr/notehub-api" target="_blank"
+                           style="text-decoration: underline; color: #999999; font-family: sans-serif; font-size: 13px; font-weight: 400; line-height: 150%;">
+                            código
+                        </a>
+                        da nossa aplicação está disponível para todos, a qualquer hora.
+                    </td>
+                </tr>
+
+                <!-- End of WRAPPER -->
+            </table>
+
+            <!-- End of SECTION / BACKGROUND -->
+        </td>
+    </tr>
+</table>
+
+</body>
+</html>


### PR DESCRIPTION
### Sumário
O PR introduz melhorias significantes para usuários vindo de aplicativos externos com autorizações abertas(OAuth).

### Alterações
- `README.md` preparado para aceitar a release 1.5;
- Permitido exclusão de usuários OAuth usando chave secreta enviada via email;
- Garantida a segurança entre tokens de alterações, para que não usem tokens de troca de email para trocar senha;
- Separado os serviços para login via GitHub e Google;
- Melhorada a validação de usernames e email ao logar via aplicações externas;
- Alterado a tipagem de String para Enum no campo host de User para garantir a tipagem correta;
- Adicionada a aplicação Jackson Databind;

### Necessidade
- Não há um universo onde usuários externos não possam excluir suas contas e alterar o email registrado;
- A validação de username e email para usuários vindo de aplicativos externos estava ruim;

### Teste manual
- Rode a aplicação;
- Crie e configure um OAuth App no GitHub;
- Faça um GET request para: https://github.com/login/oauth/authorize?client_id={seu-client-id}&scope=user:email
- Autorize e logo após copie o code retornado na URL do callback configurado no OAuth App;
- Faça um POST request para: http://localhost:8080/api/v1/auth/login/github com o seguinte body:

```java
{
   "code": "{seu-code}"
}
```

 ### Checklist
 
- [x] Código segue o padrão do projeto
- [x] Documentação atualizada
- [ ] Testes adicionados/atualizados