### PR TITLE
fix(username): support GitHub-style usernames with hyphen

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,6 @@ RUN ./mvnw clean install
 
 FROM eclipse-temurin:21-jdk-alpine
 
-COPY --from=build ./target/NoteHub-1.6.0.jar app.jar
+COPY --from=build ./target/NoteHub-1.6.1.jar app.jar
 
 ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@
 </div>
 <br>
 <div align="center">
-  <a href="https://github.com/notehubbr/notehub-api/releases/tag/v1.6">
-    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-v1.6-7c3aed">
+  <a href="https://github.com/notehubbr/notehub-api/releases/tag/v1.6.1">
+    <img width="100px" height="25px" src="https://img.shields.io/badge/notehub-1.6.1-7c3aed">
   </a>
 </div>
 

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
     </parent>
     <groupId>br.com.notehub</groupId>
     <artifactId>NoteHub</artifactId>
-    <version>1.6.0</version>
+    <version>1.6.1</version>
     <name>NoteHub</name>
     <description>https://notehub.com.br</description>
     <url/>

--- a/src/main/java/br/com/notehub/application/dto/request/user/ChangeUserREQ.java
+++ b/src/main/java/br/com/notehub/application/dto/request/user/ChangeUserREQ.java
@@ -11,7 +11,7 @@ public record ChangeUserREQ(
         @NoForbiddenWords(message = "Não pode")
         @NotBlank(message = "Não pode ser vazio")
         @Pattern(
-                regexp = "^[a-zA-Z0-9_.]+$",
+                regexp = "^[a-zA-Z0-9_.-]+$",
                 message = "Apenas letras, números, _ e ."
         )
         @Size(min = 2, max = 12, message = "Tamanho inválido")

--- a/src/main/java/br/com/notehub/application/dto/request/user/ChangeUsernameREQ.java
+++ b/src/main/java/br/com/notehub/application/dto/request/user/ChangeUsernameREQ.java
@@ -9,7 +9,7 @@ public record ChangeUsernameREQ(
         @NoForbiddenWords(message = "Não pode")
         @NotBlank(message = "Não pode ser vazio")
         @Pattern(
-                regexp = "^[a-zA-Z0-9_.]+$",
+                regexp = "^[a-zA-Z0-9_.-]+$",
                 message = "Apenas letras, números, _ e ."
         )
         @Size(min = 2, max = 12, message = "Tamanho inválido")

--- a/src/main/java/br/com/notehub/application/dto/request/user/CreateUserREQ.java
+++ b/src/main/java/br/com/notehub/application/dto/request/user/CreateUserREQ.java
@@ -18,7 +18,7 @@ public record CreateUserREQ(
         @NoForbiddenWords(message = "Não pode")
         @NotBlank(message = "Não pode ser vazio")
         @Pattern(
-                regexp = "^[a-zA-Z0-9_.]+$",
+                regexp = "^[a-zA-Z0-9_.-]+$",
                 message = "Apenas letras, números, _ e ."
         )
         @Size(min = 2, max = 12, message = "Tamanho inválido")


### PR DESCRIPTION
### Sumário

Este PR corrige validação de username para suportar hífen (`-`), permitindo compatibilidade com usernames vindos do GitHub.

### Alterações

- `pom.xml`, `Dockerfile` e `README.md` atualizados para a release **1.6.1**;
- Atualizada validação de username.

### Necessidade

- Usuários vindos do GitHub com hífen no username não conseguiam atualizar o perfil sem mudar o username primeiro.

### Teste manual

- Rode a aplicação;
- Crie um novo usuário;
- PATCH `http://localhost:8080/api/v1/users/profile/username` com payload:

```json
{
   "username": "teste-com-hifen"
}
```

### Checklist

- [x] Código segue o padrão do projeto
- [ ] Documentação atualizada
- [ ] Testes adicionados/atualizados
