### PR TITLE
ci(sync): add workflow to recreate flyio-new-files from main after merges

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,51 @@
+name: Sync main to flyio-new-files
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - closed
+
+permissions:
+  contents: write
+
+jobs:
+  sync:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main branch
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Save fly.toml from deploy branch
+        run: |
+          git fetch origin flyio-new-files || echo "No deploy branch yet"
+          mkdir temp
+          if git ls-remote --exit-code origin flyio-new-files; then
+            git checkout origin/flyio-new-files -- fly.toml || echo "No fly.toml to copy"
+            cp fly.toml temp/ || echo "No fly.toml found to copy"
+          fi
+
+      - name: Create/overwrite flyio-new-files branch
+        run: |
+          git checkout -B flyio-new-files
+          git reset --hard main
+
+      - name: Restore fly.toml
+        run: |
+          if [ -f temp/fly.toml ]; then
+            cp temp/fly.toml fly.toml
+          fi
+
+      - name: Commit and push to flyio-new-files
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "Sync main -> flyio-new-files (keeping fly.toml)" || echo "No changes to commit"
+          git push -f origin flyio-new-files


### PR DESCRIPTION
### Sumário

Este PR adiciona um workflow **GitHub Actions** responsável por automatizar a sincronização da branch `flyio-new-files` a partir da branch `main` sempre que um *pull request* é mergeado. O processo garante que a branch de deploy seja atualizada com o conteúdo mais recente da `main`, preservando o arquivo `fly.toml`, necessário para o deploy via **Fly.io**.

### Alterações

- Adiciona o workflow `.github/workflows/sync-flyio.yml`:
  - Disparado automaticamente após merges na branch `main`;
  - Faz checkout da branch `main` e copia seu conteúdo integral para a branch `flyio-new-files`;
  - Preserva o arquivo `fly.toml` da branch de deploy, evitando sobrescrita;
  - Realiza *commit* e *push* automatizados para a branch `flyio-new-files` com o conteúdo atualizado;
  - Utiliza *push forçado* (`git push -f`) para garantir que a branch seja totalmente recriada, refletindo o estado mais recente da `main`.

### Necessidade

Anteriormente, a sincronização entre `main` e `flyio-new-files` era feita manualmente após cada atualização, exigindo copiar o conteúdo da `main` e manter o arquivo `fly.toml`.  
Esta automação elimina esse processo manual, reduzindo o risco de inconsistências e acelerando o fluxo de deploy, garantindo que o ambiente **Fly.io** esteja sempre alinhado com a versão mais recente do código.

### Teste manual

- Crie um **fork de teste** do repositório principal e habilite as **GitHub Actions** nele;
- No fork, realize um *pull request* e efetue o **merge na branch `main`**;
- Após o merge, verifique se o workflow foi executado automaticamente;
- Confirme que a branch `flyio-new-files` foi:
  - Recriada com o conteúdo mais recente da `main`;
  - Preservado o arquivo `fly.toml` existente;
  - Atualizada com um *commit* automático contendo a mensagem:  
    `"Sync main -> flyio-new-files (keeping fly.toml)"`.

### Checklist

- [x] Código segue o padrão do projeto  
- [ ] Documentação atualizada  
- [ ] Testes adicionados/atualizados  

### Breaking Changes

- *Nenhuma*