### PR TITLE
chore(ci): update workflow to sync main into deploy branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Sync main to flyio-new-files
+name: Sync main to deploy
 
 on:
   pull_request:
@@ -24,16 +24,16 @@ jobs:
 
       - name: Save fly.toml from deploy branch
         run: |
-          git fetch origin flyio-new-files || echo "No deploy branch yet"
+          git fetch origin deploy || echo "No deploy branch yet"
           mkdir temp
-          if git ls-remote --exit-code origin flyio-new-files; then
-            git checkout origin/flyio-new-files -- fly.toml || echo "No fly.toml to copy"
+          if git ls-remote --exit-code origin deploy; then
+            git checkout origin/deploy -- fly.toml || echo "No fly.toml to copy"
             cp fly.toml temp/ || echo "No fly.toml found to copy"
           fi
 
-      - name: Create/overwrite flyio-new-files branch
+      - name: Create/overwrite deploy branch
         run: |
-          git checkout -B flyio-new-files
+          git checkout -B deploy
           git reset --hard main
 
       - name: Restore fly.toml
@@ -42,10 +42,10 @@ jobs:
             cp temp/fly.toml fly.toml
           fi
 
-      - name: Commit and push to flyio-new-files
+      - name: Commit and push to deploy
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "Sync main -> flyio-new-files (keeping fly.toml)" || echo "No changes to commit"
-          git push -f origin flyio-new-files
+          git commit -m "Sync main -> deploy (keeping fly.toml)" || echo "No changes to commit"
+          git push -f origin deploy


### PR DESCRIPTION
### Sumário

Este PR atualiza o workflow responsável por sincronizar automaticamente a branch `flyio-new-files` para utilizar agora a branch `deploy` como destino.  
A mudança visa padronizar a nomenclatura da branch de deploy, sem alterar o comportamento ou a lógica do processo existente.

### Alterações

- Atualiza o workflow `.github/workflows/deploy.yml` para:
  - Substituir todas as referências à branch `flyio-new-files` por `deploy`;
  - Manter o mesmo gatilho de execução (após merges na `main`);
  - Continuar preservando o arquivo `fly.toml` durante a sincronização;
  - Continuar forçando o *push* para garantir a atualização completa da branch de destino.

### Necessidade

A renomeação torna o fluxo mais intuitivo, utilizando o nome `deploy` para refletir com clareza o propósito da branch, sem impactar a automação ou o processo de sincronização existentes.

### Teste manual

- Realizar um merge na `main` e confirmar:
  - Execução automática do workflow;
  - Criação/atualização da branch `deploy` com o conteúdo da `main`;
  - Preservação do arquivo `fly.toml`;
  - *Commit* automático com a mensagem:  
    `"Sync main -> deploy (keeping fly.toml)"`.

### Checklist

- [x] Código segue o padrão do projeto  
- [ ] Documentação atualizada  
- [ ] Testes adicionados/atualizados  

### Breaking Changes

- *Nenhuma*