### PR TITLE
feat(auth): allow login with email or username

### DIFF
--- a/src/main/java/br/com/notehub/application/controller/auth/AuthController.java
+++ b/src/main/java/br/com/notehub/application/controller/auth/AuthController.java
@@ -34,10 +34,10 @@ public class AuthController {
     private final UserService userService;
     private final MailProducer producer;
 
-    @Operation(summary = "Login user", description = "Authenticates a user with username and password.")
+    @Operation(summary = "Authenticate User", description = "Authenticates a user using an account identifier and password.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "200", description = "User authenticated successfully."),
-            @ApiResponse(responseCode = "401", description = "Invalid password.", content = @Content(mediaType = "application/json")),
+            @ApiResponse(responseCode = "401", description = "Invalid identifier or password.", content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "400", description = "Missing or invalid X-Device-Id.", content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "403", description = "Email not confirmed.", content = @Content(mediaType = "application/json")),
             @ApiResponse(responseCode = "404", description = "User not found.", content = @Content(examples = {})),
@@ -49,7 +49,7 @@ public class AuthController {
             HttpServletRequest request,
             @Valid @RequestBody AuthREQ dto
     ) {
-        AuthRES token = service.auth(request, dto.username(), dto.password());
+        AuthRES token = service.auth(request, dto.identifier(), dto.password());
         return ResponseEntity.status(HttpStatus.OK).body(token);
     }
 

--- a/src/main/java/br/com/notehub/application/dto/request/token/AuthREQ.java
+++ b/src/main/java/br/com/notehub/application/dto/request/token/AuthREQ.java
@@ -2,18 +2,13 @@ package br.com.notehub.application.dto.request.token;
 
 import br.com.notehub.application.validation.constraints.NoForbiddenWords;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record AuthREQ(
         @NoForbiddenWords(message = "Não pode")
         @NotBlank
-        @Pattern(
-                regexp = "^(?!.*[\\p{Zs}\\u00A0\\u2007\\u202F]).*$",
-                message = "Não use espaços"
-        )
-        @Size(min = 2, max = 12, message = "Tamanho inválido")
-        String username,
+        @Size(min = 2, max = 255, message = "Tamanho inválido")
+        String identifier,
 
         @NotBlank
         @Size(min = 4, max = 255, message = "Tamanho inválido")

--- a/src/main/java/br/com/notehub/application/implementation/token/TokenServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/token/TokenServiceImpl.java
@@ -189,9 +189,12 @@ public class TokenServiceImpl implements TokenService {
 
     @Transactional
     @Override
-    public AuthRES auth(HttpServletRequest request, String username, String password) throws BadCredentialsException {
+    public AuthRES auth(HttpServletRequest request, String identifier, String password) throws BadCredentialsException {
 
-        User user = userRepository.findByUsername(username.toLowerCase()).orElseThrow(() -> new BadCredentialsException("username"));
+        User user = (identifier.contains("@")
+                ? userRepository.findByEmail(identifier)
+                : userRepository.findByUsername(identifier))
+                .orElseThrow(() -> new BadCredentialsException("identifier"));
         if (!user.isActive()) throw new DisabledException("Email não confirmado");
 
         boolean matches = encoder.matches(password, user.getPassword());

--- a/src/main/java/br/com/notehub/domain/token/TokenService.java
+++ b/src/main/java/br/com/notehub/domain/token/TokenService.java
@@ -26,7 +26,7 @@ public interface TokenService {
 
     String validateToken(String accessToken);
 
-    AuthRES auth(HttpServletRequest request, String username, String password) throws BadCredentialsException;
+    AuthRES auth(HttpServletRequest request, String identifier, String password) throws BadCredentialsException;
 
     AuthRES authWithGoogleAcc(HttpServletRequest request, String token);
 

--- a/src/main/java/br/com/notehub/infra/exception/ControllerAdvice.java
+++ b/src/main/java/br/com/notehub/infra/exception/ControllerAdvice.java
@@ -144,8 +144,8 @@ public class ControllerAdvice {
     private ResponseEntity<List<CustomResponse>> handleBadCredentialsException(BadCredentialsException ex) {
         List<FieldError> errors = new ArrayList<>();
         return switch (ex.getMessage()) {
-            case "username" -> {
-                errors.add(new FieldError("user", "username", "Nome não existe."));
+            case "identifier" -> {
+                errors.add(new FieldError("user", "identifier", "Identificador não existe."));
                 yield ResponseEntity.status(HttpStatus.NOT_FOUND).body(errors.stream().map(CustomResponse::new).toList());
             }
             case "password" -> {


### PR DESCRIPTION
### Sumário

Substituição do campo `username` por `identifier` no fluxo de autenticação, permitindo que o usuário faça login com e-mail ou username.

### Alterações

- `AuthREQ`: campo `username` renomeado para `identifier`, com validações ajustadas para aceitar e-mail e username
- `TokenServiceImpl`: lógica de detecção via `contains("@")` para direcionar a query correta
- `TokenService`: assinatura do método de autenticação atualizada
- `AuthController`: documentação Swagger ajustada para refletir o novo campo
- `ControllerAdvice`: ajuste nas mensagens de erro relacionadas ao identificador

### Necessidade

O fluxo anterior exigia que o usuário lembrasse do username cadastrado. A mudança melhora a experiência permitindo autenticação com e-mail, que é mais intuitivo e comum em aplicações modernas.

### Teste manual

1. Realizar login com `identifier` sendo um **username** válido
2. Realizar login com `identifier` sendo um **e-mail** válido
3. Tentar login com identificador inexistente — esperar `401`
4. Tentar login com senha incorreta — esperar `401`

### Checklist

- [x] Código segue o padrão do projeto
- [x] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes

- O campo `username` no body da requisição `POST /login` foi renomeado para `identifier` — clientes que consomem esta rota precisam atualizar o payload.