### PR TITLE
feat(auth): add session management options to credential change endpoints

### DIFF
--- a/src/main/java/br/com/notehub/application/controller/user/UserController.java
+++ b/src/main/java/br/com/notehub/application/controller/user/UserController.java
@@ -5,6 +5,7 @@ import br.com.notehub.application.dto.request.user.*;
 import br.com.notehub.application.dto.response.page.PageRES;
 import br.com.notehub.application.dto.response.user.CreateUserRES;
 import br.com.notehub.application.dto.response.user.DetailUserRES;
+import br.com.notehub.domain.token.TokenService;
 import br.com.notehub.domain.user.Subscription;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserService;
@@ -20,6 +21,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
@@ -48,6 +50,7 @@ public class UserController {
     private String client;
 
     private final UserService service;
+    private final TokenService tokenService;
     private final MailProducer producer;
 
     private UUID getSubject(String bearerToken) {
@@ -94,25 +97,33 @@ public class UserController {
     @Operation(summary = "Reset user password", description = "Resets the user's password using the provided token.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "User's password updated successfully."),
-            @ApiResponse(responseCode = "400", description = "Invalid or same password."),
+            @ApiResponse(responseCode = "400", description = """
+                    - `INVALID_DEVICE_ID`: Missing or invalid X-Device-Id
+                    - `SAME_PASSWORD`: Invalid password or new password is identical to the current one
+                    """),
             @ApiResponse(responseCode = "403", description = "Invalid token."),
             @ApiResponse(responseCode = "404", description = "User not found."),
             @ApiResponse(responseCode = "500", description = "Internal server error.")
     })
     @PatchMapping("/change-password")
     public ResponseEntity<Void> patchPassword(
+            HttpServletRequest request,
             @Parameter(hidden = true) @RequestHeader("Authorization") String token,
             @Valid @RequestBody ChangePasswordREQ dto
     ) {
         String emailFromToken = getSubject(token, "password");
         service.changePassword(emailFromToken, dto.password());
+        if (dto.disconnectAll()) tokenService.disconnectAll(request, dto.keepCurrentSession(), emailFromToken);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @Operation(summary = "Update email", description = "Updates the user's email address.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Email updated successfully."),
-            @ApiResponse(responseCode = "400", description = "Invalid or same email."),
+            @ApiResponse(responseCode = "400", description = """
+                    - `INVALID_DEVICE_ID`: Missing or invalid X-Device-Id
+                    - `SAME_EMAIL`: Invalid email or new email is identical to the current one
+                    """),
             @ApiResponse(responseCode = "403", description = "Invalid token."),
             @ApiResponse(responseCode = "404", description = "User not found."),
             @ApiResponse(responseCode = "406", description = "Email already exists."),
@@ -120,11 +131,13 @@ public class UserController {
     })
     @PatchMapping("/change-email")
     public ResponseEntity<Void> patchEmail(
+            HttpServletRequest request,
             @Parameter(hidden = true) @RequestHeader("Authorization") String token,
             @Valid @RequestBody ChangeEmailREQ dto
     ) {
         String emailFromToken = getSubject(token, "email");
         service.changeEmail(emailFromToken, dto.email());
+        if (dto.disconnectAll()) tokenService.disconnectAll(request, dto.keepCurrentSession(), emailFromToken);
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 

--- a/src/main/java/br/com/notehub/application/dto/request/user/ChangeEmailREQ.java
+++ b/src/main/java/br/com/notehub/application/dto/request/user/ChangeEmailREQ.java
@@ -9,6 +9,8 @@ public record ChangeEmailREQ(
                 regexp = "(?i)[a-z0-9!#$%&'*+=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+=?^_`{|}~-]+)*@(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?",
                 message = "Email inválido"
         )
-        String email
+        String email,
+        boolean disconnectAll,
+        boolean keepCurrentSession
 ) {
 }

--- a/src/main/java/br/com/notehub/application/dto/request/user/ChangePasswordREQ.java
+++ b/src/main/java/br/com/notehub/application/dto/request/user/ChangePasswordREQ.java
@@ -6,6 +6,8 @@ import jakarta.validation.constraints.Size;
 public record ChangePasswordREQ(
         @NotBlank(message = "Não pode ser vazio")
         @Size(min = 4, max = 255, message = "Tamanho inválido")
-        String password
+        String password,
+        boolean disconnectAll,
+        boolean keepCurrentSession
 ) {
 }

--- a/src/main/java/br/com/notehub/application/implementation/token/TokenServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/token/TokenServiceImpl.java
@@ -260,6 +260,14 @@ public class TokenServiceImpl implements TokenService {
     }
 
     @Override
+    public void disconnectAll(HttpServletRequest request, boolean keepCurrentSession, String email) {
+        List<Token> connections = repository.findAllByUserEmail(email);
+        UUID device = validateDevice(request);
+        if (keepCurrentSession) connections = connections.stream().filter(t -> !t.getDevice().equals(device)).toList();
+        repository.deleteAll(connections);
+    }
+
+    @Override
     public void cleanExpiredTokens() {
         List<Token> expiredTokens = repository.findExpiredTokens(Instant.now());
         repository.deleteAll(expiredTokens);

--- a/src/main/java/br/com/notehub/domain/token/TokenRepository.java
+++ b/src/main/java/br/com/notehub/domain/token/TokenRepository.java
@@ -15,6 +15,8 @@ public interface TokenRepository extends JpaRepository<Token, UUID> {
 
     Optional<Token> findByDevice(UUID id);
 
+    List<Token> findAllByUserEmail(String email);
+
     @Query("SELECT t FROM Token t WHERE t.expiresAt < :now")
     List<Token> findExpiredTokens(@Param("now") Instant now);
 

--- a/src/main/java/br/com/notehub/domain/token/TokenService.java
+++ b/src/main/java/br/com/notehub/domain/token/TokenService.java
@@ -36,6 +36,8 @@ public interface TokenService {
 
     void logout(HttpServletRequest request);
 
+    void disconnectAll(HttpServletRequest request, boolean keepCurrentSession, String email);
+
     void cleanExpiredTokens();
 
 }


### PR DESCRIPTION
### Sumário

Adição da funcionalidade de desconexão de sessões ao alterar senha ou e-mail, permitindo que o usuário invalide outros dispositivos ativos no momento da troca de credenciais.

### Alterações

- Adicionados os campos `disconnectAll` e `keepCurrentSession` nos DTOs `ChangePasswordREQ` e `ChangeEmailREQ`
- Injetados `TokenService` e `HttpServletRequest` no `UserController`
- Adicionadas chamadas condicionais a `tokenService.disconnectAll(...)` nos endpoints `PATCH /change-password` e `PATCH /change-email`
- Implementado o método `disconnectAll(...)` na interface `TokenService` e em `TokenServiceImpl`
- Adicionado o método `findAllByUserEmail(String email)` em `TokenRepository`
- Atualizadas as descrições de erro `400` nos endpoints afetados na documentação OpenAPI, detalhando os códigos `INVALID_DEVICE_ID` e `SAME_PASSWORD`/`SAME_EMAIL`

### Necessidade

Ao trocar senha ou e-mail, é uma boa prática de segurança permitir que o usuário encerre sessões abertas em outros dispositivos. Com os novos campos `disconnectAll` e `keepCurrentSession`, o cliente pode optar por invalidar todas as sessões (ou todas exceto a atual) no momento da atualização das credenciais.

### Teste manual

1. Autenticar com um usuário em dois dispositivos/sessões distintas
2. Na sessão principal, enviar `PATCH /users/change-password` com `disconnectAll: true` e `keepCurrentSession: false` — verificar retorno `204` e que a outra sessão foi invalidada
3. Repetir o passo anterior com `keepCurrentSession: true` — verificar que apenas a sessão atual permanece ativa
4. Enviar `PATCH /users/change-password` com `disconnectAll: false` — verificar que nenhuma sessão é encerrada
5. Repetir os passos 2, 3 e 4 para `PATCH /users/change-email`
6. Testar com `X-Device-Id` ausente ou inválido e verificar retorno `400` com código `INVALID_DEVICE_ID`

### Checklist
- [x] Código segue o padrão do projeto
- [x] Documentação atualizada
- [ ] Testes adicionados/atualizados

### Breaking Changes
- ***Nenhuma***