### PR TITLE
feat(feed): implement fan-out feed with event filtering, cleanup handlers and privacy support

### DIFF
--- a/src/main/java/br/com/notehub/application/controller/feed/FeedController.java
+++ b/src/main/java/br/com/notehub/application/controller/feed/FeedController.java
@@ -1,0 +1,49 @@
+package br.com.notehub.application.controller.feed;
+
+import br.com.notehub.application.dto.response.feed.FeedEventRES;
+import br.com.notehub.application.dto.response.page.PageRES;
+import br.com.notehub.domain.feed.FeedService;
+import com.auth0.jwt.JWT;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/feed")
+@SecurityRequirement(name = "bearer-key")
+@Tag(name = "Feed Controller", description = "Endpoint for reading user feed")
+@RequiredArgsConstructor
+public class FeedController {
+
+    private final FeedService service;
+
+    private UUID getSubject(String bearerToken) {
+        if (bearerToken == null) return null;
+        String idFromToken = JWT.decode(bearerToken.replace("Bearer ", "")).getSubject();
+        return UUID.fromString(idFromToken);
+    }
+
+    @GetMapping
+    public ResponseEntity<PageRES<FeedEventRES>> getFeed(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
+            @ParameterObject @PageableDefault(page = 0, size = 25, sort = {"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        UUID idFromToken = getSubject(accessToken);
+        PageRES<FeedEventRES> feed = service.getFeed(pageable, idFromToken);
+        return ResponseEntity.status(HttpStatus.OK).body(feed);
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/controller/feed/FeedController.java
+++ b/src/main/java/br/com/notehub/application/controller/feed/FeedController.java
@@ -5,7 +5,11 @@ import br.com.notehub.application.dto.response.page.PageRES;
 import br.com.notehub.domain.feed.FeedEvent;
 import br.com.notehub.domain.feed.FeedService;
 import com.auth0.jwt.JWT;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -23,7 +27,7 @@ import java.util.UUID;
 @RestController
 @RequestMapping("/api/v1/feed")
 @SecurityRequirement(name = "bearer-key")
-@Tag(name = "Feed Controller", description = "Endpoint for reading user feed")
+@Tag(name = "Feed Controller", description = "Endpoints for reading the authenticated user's feed")
 @RequiredArgsConstructor
 public class FeedController {
 
@@ -35,6 +39,16 @@ public class FeedController {
         return UUID.fromString(idFromToken);
     }
 
+    @Operation(
+            summary = "Get authenticated user's feed",
+            description = "Retrieves a paginated list of feed events for the authenticated user."
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Feed retrieved successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid pageable criteria or unknown event type.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "403", description = "Access token is invalid or missing.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
+    })
     @GetMapping
     public ResponseEntity<PageRES<FeedEventRES>> getFeed(
             @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,

--- a/src/main/java/br/com/notehub/application/controller/feed/FeedController.java
+++ b/src/main/java/br/com/notehub/application/controller/feed/FeedController.java
@@ -2,6 +2,7 @@ package br.com.notehub.application.controller.feed;
 
 import br.com.notehub.application.dto.response.feed.FeedEventRES;
 import br.com.notehub.application.dto.response.page.PageRES;
+import br.com.notehub.domain.feed.FeedEvent;
 import br.com.notehub.domain.feed.FeedService;
 import com.auth0.jwt.JWT;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,11 +15,9 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
 import java.util.UUID;
 
 @RestController
@@ -39,10 +38,11 @@ public class FeedController {
     @GetMapping
     public ResponseEntity<PageRES<FeedEventRES>> getFeed(
             @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
+            @RequestParam(required = false) List<FeedEvent> events,
             @ParameterObject @PageableDefault(page = 0, size = 25, sort = {"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
     ) {
         UUID idFromToken = getSubject(accessToken);
-        PageRES<FeedEventRES> feed = service.getFeed(pageable, idFromToken);
+        PageRES<FeedEventRES> feed = service.getFeed(pageable, idFromToken, events);
         return ResponseEntity.status(HttpStatus.OK).body(feed);
     }
 

--- a/src/main/java/br/com/notehub/application/controller/note/NoteController.java
+++ b/src/main/java/br/com/notehub/application/controller/note/NoteController.java
@@ -400,26 +400,6 @@ public class NoteController {
     }
 
     @Operation(
-            summary = "Get notes from followed users",
-            description = "Retrieves a paginated list of notes from users that the authenticated user is following."
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Notes retrieved successfully."),
-            @ApiResponse(responseCode = "400", description = "Invalid pageable criteria.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "403", description = "Access token is invalid or missing.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
-    })
-    @GetMapping("/private/following")
-    public ResponseEntity<PageRES<LowDetailNoteRES>> getAllFollowingUsersNotes(
-            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
-            @ParameterObject @PageableDefault(page = 0, size = 10, sort = {"createdAt"}, direction = Sort.Direction.DESC) Pageable pageable
-    ) {
-        UUID idFromToken = getSubject(accessToken);
-        PageRES<LowDetailNoteRES> page = service.getAllFollowedUsersNotes(pageable, idFromToken);
-        return ResponseEntity.status(HttpStatus.OK).body(page);
-    }
-
-    @Operation(
             summary = "Get notes from a user with mutual connections",
             description = "Retrieves a paginated list of notes from a user that the authenticated user is following."
     )

--- a/src/main/java/br/com/notehub/application/dto/response/comment/DetailCommentRES.java
+++ b/src/main/java/br/com/notehub/application/dto/response/comment/DetailCommentRES.java
@@ -1,5 +1,6 @@
 package br.com.notehub.application.dto.response.comment;
 
+import br.com.notehub.application.dto.response.note.LowDetailNoteRES;
 import br.com.notehub.application.dto.response.user.DetailUserRES;
 import br.com.notehub.domain.comment.Comment;
 
@@ -10,19 +11,21 @@ import java.util.UUID;
 
 public record DetailCommentRES(
         UUID id,
+        DetailUserRES user,
+        LowDetailNoteRES note,
         String created_at,
         String text,
         boolean modified,
-        DetailUserRES user,
         int replies_count
 ) {
     public DetailCommentRES(Comment comment) {
         this(
                 comment.getId(),
+                comment.getUser() != null ? new DetailUserRES(comment.getUser()) : null,
+                new LowDetailNoteRES(comment.getNote()),
                 comment.getCreatedAt().atZone(ZoneId.of("America/Sao_Paulo")).format(DateTimeFormatter.ofPattern("d/M/yy HH:mm", Locale.of("pt-BR"))),
                 comment.getText(),
                 comment.isModified(),
-                comment.getUser() != null ? new DetailUserRES(comment.getUser()) : null,
                 comment.getRepliesCount()
         );
     }

--- a/src/main/java/br/com/notehub/application/dto/response/feed/FeedEventRES.java
+++ b/src/main/java/br/com/notehub/application/dto/response/feed/FeedEventRES.java
@@ -7,7 +7,9 @@ import br.com.notehub.application.dto.response.user.DetailUserRES;
 import br.com.notehub.domain.feed.Feed;
 import br.com.notehub.domain.feed.FeedEvent;
 
-import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.Locale;
 
 public record FeedEventRES(
         FeedEvent event,
@@ -17,7 +19,7 @@ public record FeedEventRES(
         LowDetailNoteRES note,
         DetailFlameRES flame,
         DetailCommentRES comment,
-        Instant createdAt
+        String created_at
 ) {
     public FeedEventRES(Feed feed) {
         this(
@@ -28,7 +30,7 @@ public record FeedEventRES(
                 feed.getNote() == null ? null : new LowDetailNoteRES(feed.getNote()),
                 feed.getFlame() == null ? null : new DetailFlameRES(feed.getFlame()),
                 feed.getComment() == null ? null : new DetailCommentRES(feed.getComment()),
-                feed.getCreatedAt()
+                feed.getCreatedAt().atZone(ZoneId.of("America/Sao_Paulo")).format(DateTimeFormatter.ofPattern("d/M/yy HH:mm", Locale.of("pt-BR")))
         );
     }
 }

--- a/src/main/java/br/com/notehub/application/dto/response/feed/FeedEventRES.java
+++ b/src/main/java/br/com/notehub/application/dto/response/feed/FeedEventRES.java
@@ -1,0 +1,34 @@
+package br.com.notehub.application.dto.response.feed;
+
+import br.com.notehub.application.dto.response.comment.DetailCommentRES;
+import br.com.notehub.application.dto.response.flame.DetailFlameRES;
+import br.com.notehub.application.dto.response.note.LowDetailNoteRES;
+import br.com.notehub.application.dto.response.user.DetailUserRES;
+import br.com.notehub.domain.feed.Feed;
+import br.com.notehub.domain.feed.FeedEvent;
+
+import java.time.Instant;
+
+public record FeedEventRES(
+        FeedEvent event,
+        DetailUserRES recipient,
+        DetailUserRES actor,
+        DetailUserRES related,
+        LowDetailNoteRES note,
+        DetailFlameRES flame,
+        DetailCommentRES comment,
+        Instant createdAt
+) {
+    public FeedEventRES(Feed feed) {
+        this(
+                feed.getEvent(),
+                new DetailUserRES(feed.getRecipient()),
+                new DetailUserRES(feed.getActor()),
+                feed.getRelated() == null ? null : new DetailUserRES(feed.getRelated()),
+                feed.getNote() == null ? null : new LowDetailNoteRES(feed.getNote()),
+                feed.getFlame() == null ? null : new DetailFlameRES(feed.getFlame()),
+                feed.getComment() == null ? null : new DetailCommentRES(feed.getComment()),
+                feed.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/br/com/notehub/application/implementation/comment/CommentServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/comment/CommentServiceImpl.java
@@ -97,7 +97,6 @@ public class CommentServiceImpl implements CommentService {
         validateAccess(idFromToken, comment.getUser().getId());
         repository.delete(comment);
         counter.updateCommentsCount(comment.getNote(), false);
-        feeder.onCommentDeleted(comment.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/br/com/notehub/application/implementation/comment/CommentServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/comment/CommentServiceImpl.java
@@ -74,7 +74,7 @@ public class CommentServiceImpl implements CommentService {
         repository.save(comment);
         counter.updateCommentsCount(comment.getNote(), true);
         notifier.notify(comment.getUser(), comment.getNote().getUser(), comment.getNote().getUser(), MessageNotification.of(comment));
-        feeder.onNoteCommented(comment);
+        feeder.onNoteCommented(comment.getId());
         return new CreateCommentRES(comment);
     }
 
@@ -97,6 +97,7 @@ public class CommentServiceImpl implements CommentService {
         validateAccess(idFromToken, comment.getUser().getId());
         repository.delete(comment);
         counter.updateCommentsCount(comment.getNote(), false);
+        feeder.onCommentDeleted(comment.getId());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/br/com/notehub/application/implementation/comment/CommentServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/comment/CommentServiceImpl.java
@@ -9,6 +9,7 @@ import br.com.notehub.application.dto.response.page.PageRES;
 import br.com.notehub.domain.comment.Comment;
 import br.com.notehub.domain.comment.CommentRepository;
 import br.com.notehub.domain.comment.CommentService;
+import br.com.notehub.domain.feed.FeedService;
 import br.com.notehub.domain.note.Note;
 import br.com.notehub.domain.note.NoteRepository;
 import br.com.notehub.domain.notification.NotificationService;
@@ -36,6 +37,7 @@ public class CommentServiceImpl implements CommentService {
     private final CommentRepository repository;
     private final NotificationService notifier;
     private final Counter counter;
+    private final FeedService feeder;
 
     private void validateAccess(@Nullable UUID idFromToken, UUID idFromRequested) {
         if (idFromToken == null) throw new AccessDeniedException("Usuário sem permissão.");
@@ -72,6 +74,7 @@ public class CommentServiceImpl implements CommentService {
         repository.save(comment);
         counter.updateCommentsCount(comment.getNote(), true);
         notifier.notify(comment.getUser(), comment.getNote().getUser(), comment.getNote().getUser(), MessageNotification.of(comment));
+        feeder.onNoteCommented(comment);
         return new CreateCommentRES(comment);
     }
 

--- a/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
@@ -43,10 +43,18 @@ public class FeedServiceImpl implements FeedService {
         return requestingContainsRequested && requestedContainsRequesting;
     }
 
+    private boolean canSeeNote(Note note, Flame flame, Comment comment) {
+        if (note != null) return !note.isHidden();
+        if (flame != null) return !flame.getNote().isHidden();
+        if (comment != null) return !comment.getNote().isHidden();
+        return true;
+    }
+
     private void fanOut(FeedEvent event, User actor, User related, Note note, Flame flame, Comment comment) {
         Set<User> followers = actor.getFollowers();
         List<Feed> events = followers.stream()
                 .filter(f -> canSeeProfile(actor, f))
+                .filter(f -> canSeeNote(note, flame, comment))
                 .map(f -> new Feed(event, f, actor, related, note, flame, comment))
                 .toList();
         repository.saveAll(events);
@@ -58,7 +66,7 @@ public class FeedServiceImpl implements FeedService {
     public void onProfilePrivacyChanged(UUID actorId, boolean isPrivateProfile) {
         User user = userRepository.findById(actorId).orElseThrow(EntityNotFoundException::new);
         if (!isPrivateProfile) return;
-        repository.deleteEventsForNonMutualFollowers(user.getId());
+        repository.deleteActorEventsForNonMutualFollowers(user.getId());
     }
 
     @Async
@@ -73,12 +81,13 @@ public class FeedServiceImpl implements FeedService {
     @Async
     @Transactional
     @Override
-    public void onUserUnfollowed(UUID followerId, UUID followingId) {
-        User follower = userRepository.findById(followerId).orElseThrow(EntityNotFoundException::new);
-        repository.deleteFollowEvent(followerId, followingId);
-        repository.deleteAllEventsByActorForRecipient(followingId, followerId);
-        if (follower.isProfilePrivate()) {
-            repository.deleteAllEventsByActorForRecipient(followerId, followingId);
+    public void onUserUnfollowed(UUID unfollowingId, UUID followingId) {
+        User exfollower = userRepository.findById(unfollowingId).orElseThrow(EntityNotFoundException::new);
+        User exfollowing = userRepository.findById(followingId).orElseThrow(EntityNotFoundException::new);
+        repository.deleteActorFollowEvent(unfollowingId, followingId);
+        repository.deleteAllExRecipientEventsOnUnfollowEventByActor(followingId, unfollowingId);
+        if (!canSeeProfile(exfollowing, exfollower)) {
+            repository.deleteAllExRecipientEventsOnUnfollowEventByActor(unfollowingId, followingId);
         }
     }
 
@@ -95,15 +104,8 @@ public class FeedServiceImpl implements FeedService {
     @Transactional
     @Override
     public void onNoteHidden(UUID noteId) {
-        repository.deleteAllByNoteId(noteId);
-    }
-
-    @Async
-    @Transactional
-    @Override
-    public void onNoteDeleted(UUID noteId) {
         Note note = noteRepository.findById(noteId).orElseThrow(EntityNotFoundException::new);
-        repository.deleteAllByNoteId(note.getId());
+        if (note.isHidden()) repository.deleteAllByNoteId(noteId);
     }
 
     @Async
@@ -117,25 +119,9 @@ public class FeedServiceImpl implements FeedService {
     @Async
     @Transactional
     @Override
-    public void onNoteUnflamed(UUID flameId) {
-        Flame flame = flameRepository.findById(flameId).orElseThrow(EntityNotFoundException::new);
-        repository.deleteAllByFlameId(flame.getId());
-    }
-
-    @Async
-    @Transactional
-    @Override
     public void onNoteCommented(UUID commentId) {
         Comment comment = commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new);
         fanOut(FeedEvent.NOTE_COMMENTED, comment.getUser(), null, null, null, comment);
-    }
-
-    @Async
-    @Transactional
-    @Override
-    public void onCommentDeleted(UUID commentId) {
-        Comment comment = commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new);
-        repository.deleteAllByCommentId(comment.getId());
     }
 
     @Override

--- a/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
@@ -3,18 +3,24 @@ package br.com.notehub.application.implementation.feed;
 import br.com.notehub.application.dto.response.feed.FeedEventRES;
 import br.com.notehub.application.dto.response.page.PageRES;
 import br.com.notehub.domain.comment.Comment;
+import br.com.notehub.domain.comment.CommentRepository;
 import br.com.notehub.domain.feed.Feed;
 import br.com.notehub.domain.feed.FeedEvent;
 import br.com.notehub.domain.feed.FeedRepository;
 import br.com.notehub.domain.feed.FeedService;
 import br.com.notehub.domain.flame.Flame;
+import br.com.notehub.domain.flame.FlameRepository;
 import br.com.notehub.domain.note.Note;
+import br.com.notehub.domain.note.NoteRepository;
 import br.com.notehub.domain.user.User;
+import br.com.notehub.domain.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Set;
@@ -25,6 +31,10 @@ import java.util.UUID;
 public class FeedServiceImpl implements FeedService {
 
     private final FeedRepository repository;
+    private final UserRepository userRepository;
+    private final NoteRepository noteRepository;
+    private final FlameRepository flameRepository;
+    private final CommentRepository commentRepository;
 
     private boolean canSeeProfile(User requesting, User requested) {
         if (!requested.isProfilePrivate()) return true;
@@ -43,28 +53,89 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Async
+    @Transactional
     @Override
-    public void onUserFollowed(User follower, User following) {
+    public void onProfilePrivacyChanged(UUID actorId, boolean isPrivateProfile) {
+        User user = userRepository.findById(actorId).orElseThrow(EntityNotFoundException::new);
+        if (!isPrivateProfile) return;
+        repository.deleteEventsForNonMutualFollowers(user.getId());
+    }
+
+    @Async
+    @Transactional
+    @Override
+    public void onUserFollowed(UUID followerId, UUID followingId) {
+        User follower = userRepository.findById(followerId).orElseThrow(EntityNotFoundException::new);
+        User following = userRepository.findById(followingId).orElseThrow(EntityNotFoundException::new);
         fanOut(FeedEvent.USER_FOLLOWED, follower, following, null, null, null);
     }
 
     @Async
+    @Transactional
     @Override
-    public void onNoteCreated(Note note) {
+    public void onUserUnfollowed(UUID followerId, UUID followingId) {
+        User follower = userRepository.findById(followerId).orElseThrow(EntityNotFoundException::new);
+        repository.deleteFollowEvent(followerId, followingId);
+        repository.deleteAllEventsByActorForRecipient(followingId, followerId);
+        if (follower.isProfilePrivate()) {
+            repository.deleteAllEventsByActorForRecipient(followerId, followingId);
+        }
+    }
+
+    @Async
+    @Transactional
+    @Override
+    public void onNoteCreated(UUID noteId) {
+        Note note = noteRepository.findById(noteId).orElseThrow(EntityNotFoundException::new);
         if (note.isHidden()) return;
         fanOut(FeedEvent.NOTE_CREATED, note.getUser(), null, note, null, null);
     }
 
     @Async
+    @Transactional
     @Override
-    public void onNoteFlamed(Flame flame) {
+    public void onNoteHidden(UUID noteId) {
+        repository.deleteAllByNoteId(noteId);
+    }
+
+    @Async
+    @Transactional
+    @Override
+    public void onNoteDeleted(UUID noteId) {
+        Note note = noteRepository.findById(noteId).orElseThrow(EntityNotFoundException::new);
+        repository.deleteAllByNoteId(note.getId());
+    }
+
+    @Async
+    @Transactional
+    @Override
+    public void onNoteFlamed(UUID flameId) {
+        Flame flame = flameRepository.findById(flameId).orElseThrow(EntityNotFoundException::new);
         fanOut(FeedEvent.NOTE_FLAMED, flame.getUser(), null, null, flame, null);
     }
 
     @Async
+    @Transactional
     @Override
-    public void onNoteCommented(Comment comment) {
+    public void onNoteUnflamed(UUID flameId) {
+        Flame flame = flameRepository.findById(flameId).orElseThrow(EntityNotFoundException::new);
+        repository.deleteAllByFlameId(flame.getId());
+    }
+
+    @Async
+    @Transactional
+    @Override
+    public void onNoteCommented(UUID commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new);
         fanOut(FeedEvent.NOTE_COMMENTED, comment.getUser(), null, null, null, comment);
+    }
+
+    @Async
+    @Transactional
+    @Override
+    public void onCommentDeleted(UUID commentId) {
+        Comment comment = commentRepository.findById(commentId).orElseThrow(EntityNotFoundException::new);
+        repository.deleteAllByCommentId(comment.getId());
     }
 
     @Override

--- a/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
@@ -4,10 +4,7 @@ import br.com.notehub.application.dto.response.feed.FeedEventRES;
 import br.com.notehub.application.dto.response.page.PageRES;
 import br.com.notehub.domain.comment.Comment;
 import br.com.notehub.domain.comment.CommentRepository;
-import br.com.notehub.domain.feed.Feed;
-import br.com.notehub.domain.feed.FeedEvent;
-import br.com.notehub.domain.feed.FeedRepository;
-import br.com.notehub.domain.feed.FeedService;
+import br.com.notehub.domain.feed.*;
 import br.com.notehub.domain.flame.Flame;
 import br.com.notehub.domain.flame.FlameRepository;
 import br.com.notehub.domain.note.Note;
@@ -18,6 +15,7 @@ import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -125,10 +123,11 @@ public class FeedServiceImpl implements FeedService {
     }
 
     @Override
-    public PageRES<FeedEventRES> getFeed(Pageable pageable, UUID recipientId) {
-        Page<FeedEventRES> page = repository
-                .findFeedForUser(pageable, recipientId)
-                .map(FeedEventRES::new);
+    public PageRES<FeedEventRES> getFeed(Pageable pageable, UUID recipientId, List<FeedEvent> events) {
+        Specification<Feed> spec = Specification
+                .where(FeedSpec.forRecipient(recipientId))
+                .and(FeedSpec.withEvents(events));
+        Page<FeedEventRES> page = repository.findAll(spec, pageable).map(FeedEventRES::new);
         return new PageRES<>(page);
     }
 

--- a/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
@@ -1,0 +1,78 @@
+package br.com.notehub.application.implementation.feed;
+
+import br.com.notehub.application.dto.response.feed.FeedEventRES;
+import br.com.notehub.application.dto.response.page.PageRES;
+import br.com.notehub.domain.comment.Comment;
+import br.com.notehub.domain.feed.Feed;
+import br.com.notehub.domain.feed.FeedEvent;
+import br.com.notehub.domain.feed.FeedRepository;
+import br.com.notehub.domain.feed.FeedService;
+import br.com.notehub.domain.flame.Flame;
+import br.com.notehub.domain.note.Note;
+import br.com.notehub.domain.user.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FeedServiceImpl implements FeedService {
+
+    private final FeedRepository repository;
+
+    private boolean canSeeProfile(User requesting, User requested) {
+        if (!requested.isProfilePrivate()) return true;
+        boolean requestedContainsRequesting = requested.getFollowing().contains(requesting);
+        boolean requestingContainsRequested = requesting.getFollowing().contains(requested);
+        return requestingContainsRequested && requestedContainsRequesting;
+    }
+
+    private void fanOut(FeedEvent event, User actor, User related, Note note, Flame flame, Comment comment) {
+        Set<User> followers = actor.getFollowers();
+        List<Feed> events = followers.stream()
+                .filter(f -> canSeeProfile(actor, f))
+                .map(f -> new Feed(event, f, actor, related, note, flame, comment))
+                .toList();
+        repository.saveAll(events);
+    }
+
+    @Async
+    @Override
+    public void onUserFollowed(User follower, User following) {
+        fanOut(FeedEvent.USER_FOLLOWED, follower, following, null, null, null);
+    }
+
+    @Async
+    @Override
+    public void onNoteCreated(Note note) {
+        if (note.isHidden()) return;
+        fanOut(FeedEvent.NOTE_CREATED, note.getUser(), null, note, null, null);
+    }
+
+    @Async
+    @Override
+    public void onNoteFlamed(Flame flame) {
+        fanOut(FeedEvent.NOTE_FLAMED, flame.getUser(), null, null, flame, null);
+    }
+
+    @Async
+    @Override
+    public void onNoteCommented(Comment comment) {
+        fanOut(FeedEvent.NOTE_COMMENTED, comment.getUser(), null, null, null, comment);
+    }
+
+    @Override
+    public PageRES<FeedEventRES> getFeed(Pageable pageable, UUID recipientId) {
+        Page<FeedEventRES> page = repository
+                .findFeedForUser(pageable, recipientId)
+                .map(FeedEventRES::new);
+        return new PageRES<>(page);
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/implementation/flame/FlameServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/flame/FlameServiceImpl.java
@@ -4,6 +4,7 @@ import br.com.notehub.application.counter.Counter;
 import br.com.notehub.application.dto.notification.MessageNotification;
 import br.com.notehub.application.dto.response.flame.DetailFlameRES;
 import br.com.notehub.application.dto.response.page.PageRES;
+import br.com.notehub.domain.feed.FeedService;
 import br.com.notehub.domain.flame.Flame;
 import br.com.notehub.domain.flame.FlameRepository;
 import br.com.notehub.domain.flame.FlameService;
@@ -34,6 +35,7 @@ public class FlameServiceImpl implements FlameService {
     private final FlameRepository repository;
     private final NotificationService notifier;
     private final Counter counter;
+    private final FeedService feeder;
 
     private void validateBidirectionalFollowAccess(@Nullable User requesting, User requested) {
         if (!requested.isProfilePrivate()) return;
@@ -55,6 +57,7 @@ public class FlameServiceImpl implements FlameService {
         Flame flame = repository.save(new Flame(user, note));
         counter.updateFlamesCount(note, true);
         notifier.notify(flame.getUser(), note.getUser(), note.getUser(), MessageNotification.of(flame));
+        feeder.onNoteFlamed(flame);
         return new DetailFlameRES(flame);
     }
 

--- a/src/main/java/br/com/notehub/application/implementation/flame/FlameServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/flame/FlameServiceImpl.java
@@ -57,7 +57,7 @@ public class FlameServiceImpl implements FlameService {
         Flame flame = repository.save(new Flame(user, note));
         counter.updateFlamesCount(note, true);
         notifier.notify(flame.getUser(), note.getUser(), note.getUser(), MessageNotification.of(flame));
-        feeder.onNoteFlamed(flame);
+        feeder.onNoteFlamed(flame.getId());
         return new DetailFlameRES(flame);
     }
 
@@ -66,6 +66,7 @@ public class FlameServiceImpl implements FlameService {
     public void deflame(UUID userIdFromToken, UUID noteIdFromPath) {
         Flame flame = repository.findByUserIdAndNoteId(userIdFromToken, noteIdFromPath).orElseThrow(EntityNotFoundException::new);
         counter.updateFlamesCount(flame.getNote(), false);
+        feeder.onNoteUnflamed(flame.getId());
         repository.delete(flame);
     }
 

--- a/src/main/java/br/com/notehub/application/implementation/flame/FlameServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/flame/FlameServiceImpl.java
@@ -65,9 +65,8 @@ public class FlameServiceImpl implements FlameService {
     @Override
     public void deflame(UUID userIdFromToken, UUID noteIdFromPath) {
         Flame flame = repository.findByUserIdAndNoteId(userIdFromToken, noteIdFromPath).orElseThrow(EntityNotFoundException::new);
-        counter.updateFlamesCount(flame.getNote(), false);
-        feeder.onNoteUnflamed(flame.getId());
         repository.delete(flame);
+        counter.updateFlamesCount(flame.getNote(), false);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
@@ -5,6 +5,7 @@ import br.com.notehub.application.dto.request.note.CreateNoteREQ;
 import br.com.notehub.application.dto.response.note.DetailNoteRES;
 import br.com.notehub.application.dto.response.note.LowDetailNoteRES;
 import br.com.notehub.application.dto.response.page.PageRES;
+import br.com.notehub.domain.feed.FeedService;
 import br.com.notehub.domain.note.Note;
 import br.com.notehub.domain.note.NoteRepository;
 import br.com.notehub.domain.note.NoteService;
@@ -34,6 +35,7 @@ public class NoteServiceImpl implements NoteService {
     private final TagRepository tagRepository;
     private final NoteRepository repository;
     private final Counter counter;
+    private final FeedService feeder;
 
     private void validateAccess(@Nullable UUID idFromToken, UUID idFromRequested) {
         if (idFromToken == null) throw new AccessDeniedException("Usuário sem permissão.");
@@ -92,6 +94,7 @@ public class NoteServiceImpl implements NoteService {
         Note note = mapToNote(idFromToken, req);
         repository.save(note);
         counter.updateNotesCount(note.getUser(), true);
+        feeder.onNoteCreated(note);
         return new LowDetailNoteRES(note);
     }
 

--- a/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
@@ -94,7 +94,7 @@ public class NoteServiceImpl implements NoteService {
         Note note = mapToNote(idFromToken, req);
         repository.save(note);
         counter.updateNotesCount(note.getUser(), true);
-        feeder.onNoteCreated(note);
+        feeder.onNoteCreated(note.getId());
         return new LowDetailNoteRES(note);
     }
 
@@ -140,6 +140,7 @@ public class NoteServiceImpl implements NoteService {
     @Override
     public void changeHidden(UUID idFromToken, UUID idFromPath) {
         changeField(idFromToken, idFromPath, note -> note.setHidden(!note.isHidden()));
+        feeder.onNoteHidden(idFromPath);
     }
 
     @Transactional
@@ -161,6 +162,7 @@ public class NoteServiceImpl implements NoteService {
         deleteNoteAndFlush(note);
         removeOrphanTags(oldTagNames);
         counter.updateNotesCount(note.getUser(), false);
+        feeder.onNoteDeleted(note.getId());
     }
 
     @Transactional

--- a/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
@@ -23,9 +23,11 @@ import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 @Component
 @RequiredArgsConstructor
@@ -260,17 +262,6 @@ public class NoteServiceImpl implements NoteService {
     @Override
     public PageRES<LowDetailNoteRES> getAllUserNotesById(Pageable pageable, UUID idFromToken) {
         Page<LowDetailNoteRES> page = repository.findAllByUserId(pageable, idFromToken).map(LowDetailNoteRES::new);
-        return new PageRES<>(page);
-    }
-
-    @Override
-    public PageRES<LowDetailNoteRES> getAllFollowedUsersNotes(Pageable pageable, UUID idFromToken) {
-        User user = userRepository.findByIdWithFollowersAndFollowing(idFromToken).orElseThrow(EntityNotFoundException::new);
-        Set<UUID> following = user.getFollowing().stream().map(User::getId).collect(Collectors.toSet());
-        Set<UUID> followers = user.getFollowers().stream().map(User::getId).collect(Collectors.toSet());
-        Set<UUID> mutuals = new HashSet<>(following);
-        mutuals.retainAll(followers);
-        Page<LowDetailNoteRES> page = repository.findAllForUserFeed(pageable, following, mutuals).map(LowDetailNoteRES::new);
         return new PageRES<>(page);
     }
 

--- a/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
@@ -110,6 +110,7 @@ public class NoteServiceImpl implements NoteService {
             note.setHidden(hidden);
             removeOrphanTags(oldTags);
         });
+        feeder.onNoteHidden(idFromPath);
     }
 
     @Transactional
@@ -162,7 +163,6 @@ public class NoteServiceImpl implements NoteService {
         deleteNoteAndFlush(note);
         removeOrphanTags(oldTagNames);
         counter.updateNotesCount(note.getUser(), false);
-        feeder.onNoteDeleted(note.getId());
     }
 
     @Transactional

--- a/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
@@ -191,6 +191,8 @@ public class UserServiceImpl implements UserService {
     @Override
     public void changeProfileVisibility(UUID idFromToken) {
         changeField(idFromToken, "profile_private", User::isProfilePrivate, user -> user.setProfilePrivate(!user.isProfilePrivate()));
+        User actor = repository.findById(idFromToken).orElseThrow(EntityNotFoundException::new);
+        feeder.onProfilePrivacyChanged(actor.getId(), actor.isProfilePrivate());
     }
 
     @Transactional
@@ -250,7 +252,7 @@ public class UserServiceImpl implements UserService {
         if (isFollowing(follower, following)) throw new AlreadyFollowingException();
         counter.updateFollowersAndFollowingCount(follower, following, true);
         notifier.notify(follower, following, follower, MessageNotification.of(follower));
-        feeder.onUserFollowed(follower, following);
+        feeder.onUserFollowed(follower.getId(), following.getId());
     }
 
     @Transactional
@@ -260,6 +262,7 @@ public class UserServiceImpl implements UserService {
         User following = repository.findByUsernameWithFollowersAndFollowing(username).orElseThrow(EntityNotFoundException::new);
         if (!isFollowing(follower, following)) throw new NotFollowingException();
         counter.updateFollowersAndFollowingCount(follower, following, false);
+        feeder.onUserUnfollowed(follower.getId(), following.getId());
     }
 
     @Transactional

--- a/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
@@ -2,6 +2,7 @@ package br.com.notehub.application.implementation.user;
 
 import br.com.notehub.application.counter.Counter;
 import br.com.notehub.application.dto.notification.MessageNotification;
+import br.com.notehub.domain.feed.FeedService;
 import br.com.notehub.domain.history.UserHistoryService;
 import br.com.notehub.domain.note.NoteService;
 import br.com.notehub.domain.notification.NotificationService;
@@ -46,6 +47,7 @@ public class UserServiceImpl implements UserService {
     private final NoteService noteService;
     private final PasswordEncoder encoder;
     private final Counter counter;
+    private final FeedService feeder;
 
     private void validateGif(User user, String img, String field) {
         if (img == null || !img.endsWith(".gif")) return;
@@ -248,6 +250,7 @@ public class UserServiceImpl implements UserService {
         if (isFollowing(follower, following)) throw new AlreadyFollowingException();
         counter.updateFollowersAndFollowingCount(follower, following, true);
         notifier.notify(follower, following, follower, MessageNotification.of(follower));
+        feeder.onUserFollowed(follower, following);
     }
 
     @Transactional

--- a/src/main/java/br/com/notehub/domain/feed/Feed.java
+++ b/src/main/java/br/com/notehub/domain/feed/Feed.java
@@ -1,0 +1,71 @@
+package br.com.notehub.domain.feed;
+
+import br.com.notehub.domain.comment.Comment;
+import br.com.notehub.domain.flame.Flame;
+import br.com.notehub.domain.note.Note;
+import br.com.notehub.domain.user.User;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.Instant;
+import java.util.UUID;
+
+@Entity
+@Table(name = "feed")
+@NoArgsConstructor
+@Data
+public class Feed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    private UUID id;
+
+    private Instant createdAt = Instant.now();
+
+    @Convert(converter = FeedEventConverter.class)
+    private FeedEvent event;
+
+    @JoinColumn(name = "recipient_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private User recipient;
+
+    @JoinColumn(name = "actor_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private User actor;
+
+    @JoinColumn(name = "related_user_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private User related;
+
+    @JoinColumn(name = "note_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private Note note;
+
+    @JoinColumn(name = "flame_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private Flame flame;
+
+    @JoinColumn(name = "comment_id")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.SET_NULL)
+    private Comment comment;
+
+    public Feed(FeedEvent event, User recipient, User actor, User related, Note note, Flame flame, Comment comment) {
+        this.event = event;
+        this.recipient = recipient;
+        this.actor = actor;
+        this.related = related;
+        this.note = note;
+        this.flame = flame;
+        this.comment = comment;
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/feed/Feed.java
+++ b/src/main/java/br/com/notehub/domain/feed/Feed.java
@@ -35,27 +35,27 @@ public class Feed {
 
     @JoinColumn(name = "actor_id")
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User actor;
 
     @JoinColumn(name = "related_user_id")
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private User related;
 
     @JoinColumn(name = "note_id")
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Note note;
 
     @JoinColumn(name = "flame_id")
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Flame flame;
 
     @JoinColumn(name = "comment_id")
     @ManyToOne(fetch = FetchType.LAZY)
-    @OnDelete(action = OnDeleteAction.SET_NULL)
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Comment comment;
 
     public Feed(FeedEvent event, User recipient, User actor, User related, Note note, Flame flame, Comment comment) {

--- a/src/main/java/br/com/notehub/domain/feed/FeedEvent.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedEvent.java
@@ -1,0 +1,25 @@
+package br.com.notehub.domain.feed;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import lombok.Getter;
+
+@Getter
+public enum FeedEvent {
+
+    USER_FOLLOWED("User_Followed"),
+    NOTE_CREATED("Note_Created"),
+    NOTE_FLAMED("Note_Flamed"),
+    NOTE_COMMENTED("Note_Commented");
+
+    private final String event;
+
+    FeedEvent(String event) {
+        this.event = event;
+    }
+
+    @JsonValue
+    public String getEvent() {
+        return event;
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/feed/FeedEventConverter.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedEventConverter.java
@@ -1,0 +1,25 @@
+package br.com.notehub.domain.feed;
+
+import jakarta.persistence.AttributeConverter;
+import jakarta.persistence.Converter;
+
+@Converter
+public class FeedEventConverter implements AttributeConverter<FeedEvent, String> {
+
+    @Override
+    public String convertToDatabaseColumn(FeedEvent event) {
+        return event.getEvent();
+    }
+
+    @Override
+    public FeedEvent convertToEntityAttribute(String event) {
+        if (event == null) return null;
+        for (FeedEvent fe : FeedEvent.values()) {
+            if (fe.getEvent().equals(event)) {
+                return fe;
+            }
+        }
+        throw new IllegalArgumentException("Unknown value: " + event);
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/feed/FeedEventParamConverter.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedEventParamConverter.java
@@ -1,0 +1,18 @@
+package br.com.notehub.domain.feed;
+
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+@Component
+public class FeedEventParamConverter implements Converter<String, FeedEvent> {
+
+    @Override
+    public FeedEvent convert(@NonNull String source) {
+        for (FeedEvent fe : FeedEvent.values()) {
+            if (fe.getEvent().equals(source) || fe.name().equals(source)) return fe;
+        }
+        throw new IllegalArgumentException("Unknown source: " + source);
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
@@ -36,7 +36,7 @@ public interface FeedRepository extends JpaRepository<Feed, UUID> {
                 AND f1.id = f2.id
             )
             """)
-    void deleteEventsForNonMutualFollowers(@Param("actorId") UUID actorId);
+    void deleteActorEventsForNonMutualFollowers(@Param("actorId") UUID actorId);
 
     @Modifying
     @Query("""
@@ -45,7 +45,7 @@ public interface FeedRepository extends JpaRepository<Feed, UUID> {
             AND f.related.id = :followingId
             AND f.event = 'User_Followed'
             """)
-    void deleteFollowEvent(@Param("followerId") UUID followerId, @Param("followingId") UUID followingId);
+    void deleteActorFollowEvent(@Param("followerId") UUID followerId, @Param("followingId") UUID followingId);
 
     @Modifying
     @Query("""
@@ -53,14 +53,8 @@ public interface FeedRepository extends JpaRepository<Feed, UUID> {
             WHERE f.actor.id = :actorId
             AND f.recipient.id = :recipientId
             """)
-    void deleteAllEventsByActorForRecipient(@Param("actorId") UUID actorId, @Param("recipientId") UUID recipientId);
+    void deleteAllExRecipientEventsOnUnfollowEventByActor(@Param("actorId") UUID actorId, @Param("recipientId") UUID recipientId);
 
     void deleteAllByNoteId(UUID noteId);
-
-    void deleteAllByFlameId(UUID flameId);
-
-    void deleteAllByCommentId(UUID commentId);
-
-    void deleteAllByActorId(UUID actorId);
 
 }

--- a/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
@@ -3,6 +3,7 @@ package br.com.notehub.domain.feed;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
@@ -23,7 +24,42 @@ public interface FeedRepository extends JpaRepository<Feed, UUID> {
             """)
     Page<Feed> findFeedForUser(Pageable pageable, @Param("recipientId") UUID recipientId);
 
+    @Modifying
+    @Query("""
+            DELETE FROM Feed f
+            WHERE f.actor.id = :actorId
+            AND f.recipient.id NOT IN (
+                SELECT f1.id FROM User actor
+                JOIN actor.followers f1
+                JOIN actor.following f2
+                WHERE actor.id = :actorId
+                AND f1.id = f2.id
+            )
+            """)
+    void deleteEventsForNonMutualFollowers(@Param("actorId") UUID actorId);
+
+    @Modifying
+    @Query("""
+            DELETE FROM Feed f
+            WHERE f.actor.id = :followerId
+            AND f.related.id = :followingId
+            AND f.event = 'User_Followed'
+            """)
+    void deleteFollowEvent(@Param("followerId") UUID followerId, @Param("followingId") UUID followingId);
+
+    @Modifying
+    @Query("""
+            DELETE FROM Feed f
+            WHERE f.actor.id = :actorId
+            AND f.recipient.id = :recipientId
+            """)
+    void deleteAllEventsByActorForRecipient(@Param("actorId") UUID actorId, @Param("recipientId") UUID recipientId);
+
     void deleteAllByNoteId(UUID noteId);
+
+    void deleteAllByFlameId(UUID flameId);
+
+    void deleteAllByCommentId(UUID commentId);
 
     void deleteAllByActorId(UUID actorId);
 

--- a/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
@@ -1,8 +1,7 @@
 package br.com.notehub.domain.feed;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -11,18 +10,7 @@ import org.springframework.stereotype.Repository;
 import java.util.UUID;
 
 @Repository
-public interface FeedRepository extends JpaRepository<Feed, UUID> {
-
-    @Query("""
-            SELECT f FROM Feed f
-            LEFT JOIN FETCH f.actor a
-            LEFT JOIN FETCH f.note n
-            LEFT JOIN FETCH f.comment c
-            LEFT JOIN FETCH f.related r
-            WHERE f.recipient.id = :recipientId
-            ORDER BY f.createdAt DESC
-            """)
-    Page<Feed> findFeedForUser(Pageable pageable, @Param("recipientId") UUID recipientId);
+public interface FeedRepository extends JpaRepository<Feed, UUID>, JpaSpecificationExecutor<Feed> {
 
     @Modifying
     @Query("""

--- a/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
@@ -1,0 +1,30 @@
+package br.com.notehub.domain.feed;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FeedRepository extends JpaRepository<Feed, UUID> {
+
+    @Query("""
+            SELECT f FROM Feed f
+            LEFT JOIN FETCH f.actor a
+            LEFT JOIN FETCH f.note n
+            LEFT JOIN FETCH f.comment c
+            LEFT JOIN FETCH f.related r
+            WHERE f.recipient.id = :recipientId
+            ORDER BY f.createdAt DESC
+            """)
+    Page<Feed> findFeedForUser(Pageable pageable, @Param("recipientId") UUID recipientId);
+
+    void deleteAllByNoteId(UUID noteId);
+
+    void deleteAllByActorId(UUID actorId);
+
+}

--- a/src/main/java/br/com/notehub/domain/feed/FeedService.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedService.java
@@ -5,6 +5,7 @@ import br.com.notehub.application.dto.response.page.PageRES;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.UUID;
 
 @Service
@@ -24,6 +25,6 @@ public interface FeedService {
 
     void onNoteCommented(UUID commentId);
 
-    PageRES<FeedEventRES> getFeed(Pageable pageable, UUID recipientId);
+    PageRES<FeedEventRES> getFeed(Pageable pageable, UUID recipientId, List<FeedEvent> events);
 
 }

--- a/src/main/java/br/com/notehub/domain/feed/FeedService.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedService.java
@@ -1,0 +1,27 @@
+package br.com.notehub.domain.feed;
+
+import br.com.notehub.application.dto.response.feed.FeedEventRES;
+import br.com.notehub.application.dto.response.page.PageRES;
+import br.com.notehub.domain.comment.Comment;
+import br.com.notehub.domain.flame.Flame;
+import br.com.notehub.domain.note.Note;
+import br.com.notehub.domain.user.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.UUID;
+
+@Service
+public interface FeedService {
+
+    void onUserFollowed(User follower, User following);
+
+    void onNoteCreated(Note note);
+
+    void onNoteCommented(Comment comment);
+
+    void onNoteFlamed(Flame flame);
+
+    PageRES<FeedEventRES> getFeed(Pageable pageable, UUID recipientId);
+
+}

--- a/src/main/java/br/com/notehub/domain/feed/FeedService.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedService.java
@@ -2,10 +2,6 @@ package br.com.notehub.domain.feed;
 
 import br.com.notehub.application.dto.response.feed.FeedEventRES;
 import br.com.notehub.application.dto.response.page.PageRES;
-import br.com.notehub.domain.comment.Comment;
-import br.com.notehub.domain.flame.Flame;
-import br.com.notehub.domain.note.Note;
-import br.com.notehub.domain.user.User;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
@@ -14,13 +10,25 @@ import java.util.UUID;
 @Service
 public interface FeedService {
 
-    void onUserFollowed(User follower, User following);
+    void onProfilePrivacyChanged(UUID actorId, boolean isPrivateProfile);
 
-    void onNoteCreated(Note note);
+    void onUserFollowed(UUID followerId, UUID followingId);
 
-    void onNoteCommented(Comment comment);
+    void onUserUnfollowed(UUID followerId, UUID followingId);
 
-    void onNoteFlamed(Flame flame);
+    void onNoteCreated(UUID noteId);
+
+    void onNoteHidden(UUID noteId);
+
+    void onNoteDeleted(UUID noteId);
+
+    void onNoteFlamed(UUID flameId);
+
+    void onNoteUnflamed(UUID flameId);
+
+    void onNoteCommented(UUID commentId);
+
+    void onCommentDeleted(UUID commentId);
 
     PageRES<FeedEventRES> getFeed(Pageable pageable, UUID recipientId);
 

--- a/src/main/java/br/com/notehub/domain/feed/FeedService.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedService.java
@@ -14,21 +14,15 @@ public interface FeedService {
 
     void onUserFollowed(UUID followerId, UUID followingId);
 
-    void onUserUnfollowed(UUID followerId, UUID followingId);
+    void onUserUnfollowed(UUID unfollowingId, UUID followingId);
 
     void onNoteCreated(UUID noteId);
 
     void onNoteHidden(UUID noteId);
 
-    void onNoteDeleted(UUID noteId);
-
     void onNoteFlamed(UUID flameId);
 
-    void onNoteUnflamed(UUID flameId);
-
     void onNoteCommented(UUID commentId);
-
-    void onCommentDeleted(UUID commentId);
 
     PageRES<FeedEventRES> getFeed(Pageable pageable, UUID recipientId);
 

--- a/src/main/java/br/com/notehub/domain/feed/FeedSpec.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedSpec.java
@@ -1,0 +1,20 @@
+package br.com.notehub.domain.feed;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+import java.util.UUID;
+
+public class FeedSpec {
+
+    public static Specification<Feed> forRecipient(UUID recipientId) {
+        return (root, query, cb) -> cb.equal(root.get("recipient").get("id"), recipientId);
+    }
+
+    public static Specification<Feed> withEvents(List<FeedEvent> events) {
+        return (root, query, cb) -> events == null || events.isEmpty()
+                ? cb.conjunction()
+                : root.get("event").in(events);
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/note/NoteRepository.java
+++ b/src/main/java/br/com/notehub/domain/note/NoteRepository.java
@@ -9,7 +9,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 
 @Repository
@@ -115,19 +114,6 @@ public interface NoteRepository extends JpaRepository<Note, UUID> {
 
     @EntityGraph(attributePaths = {"user", "tags"})
     Page<Note> findAllByUserProfilePrivateFalseAndUserUsernameAndHiddenFalse(Pageable pageable, String username);
-
-    @Query("""
-            SELECT DISTINCT n FROM Note n
-            LEFT JOIN FETCH n.user u
-            LEFT JOIN FETCH n.tags t
-            WHERE n.hidden = false
-            AND (
-                (u.profilePrivate = false AND u.id IN :following)
-                OR
-                (u.id IN :mutuals)
-            )
-            """)
-    Page<Note> findAllForUserFeed(Pageable pageable, Set<UUID> following, Set<UUID> mutuals);
 
     @EntityGraph(attributePaths = {"user", "tags"})
     Page<Note> findAllByUserUsernameAndHiddenFalse(Pageable pageable, String username);

--- a/src/main/java/br/com/notehub/domain/note/NoteService.java
+++ b/src/main/java/br/com/notehub/domain/note/NoteService.java
@@ -58,8 +58,6 @@ public interface NoteService {
 
     PageRES<LowDetailNoteRES> getAllUserNotesById(Pageable pageable, UUID idFromToken);
 
-    PageRES<LowDetailNoteRES> getAllFollowedUsersNotes(Pageable pageable, UUID idFromToken);
-
     PageRES<LowDetailNoteRES> getAllFollowedUserNotes(Pageable pageable, UUID idFromToken, String username);
 
 }

--- a/src/main/resources/db/migration/V20260529__create_table_feed.sql
+++ b/src/main/resources/db/migration/V20260529__create_table_feed.sql
@@ -1,0 +1,13 @@
+CREATE TABLE feed (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    event VARCHAR(50) NOT NULL,
+    recipient_id UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    actor_id UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+    related_user_id UUID REFERENCES users (id) ON DELETE CASCADE,
+    note_id UUID REFERENCES notes (id) ON DELETE CASCADE,
+    flame_id UUID REFERENCES flames (id) ON DELETE CASCADE,
+    comment_id UUID REFERENCES comments (id) ON DELETE CASCADE
+);
+
+CREATE INDEX idx_feed_recipient_created ON feed (recipient_id, created_at DESC);

--- a/src/test/java/br/com/notehub/implementation/user/UserRelationshipTest.java
+++ b/src/test/java/br/com/notehub/implementation/user/UserRelationshipTest.java
@@ -3,6 +3,7 @@ package br.com.notehub.implementation.user;
 import br.com.notehub.application.counter.Counter;
 import br.com.notehub.application.dto.notification.MessageNotification;
 import br.com.notehub.application.implementation.user.UserServiceImpl;
+import br.com.notehub.domain.feed.FeedService;
 import br.com.notehub.domain.notification.NotificationService;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserRepository;
@@ -35,6 +36,9 @@ public class UserRelationshipTest {
 
     @Mock
     private Counter counter;
+
+    @Mock
+    private FeedService feeder;
 
     private User follower;
     private User following;


### PR DESCRIPTION
### Sumário
Implementação do sistema de feed baseado em fan-out para o NoteHub. O feed agrega eventos de usuários seguidos — criação de notas, chamas, comentários e novos follows — e os distribui para os seguidores do actor no momento do evento. O sistema respeita a política de privacidade de perfil, filtrando eventos de usuários privados para não-mútuos.

### Alterações
- Adicionado `Feed`, `FeedEvent`, `FeedEventConverter`, `FeedEventParamConverter`, `FeedRepository`, `FeedService`, `FeedServiceImpl`, `FeedSpec` e `FeedController`
- Adicionado `FeedEventRES` e atualizado `DetailCommentRES` para incluir `note`
- Integrado `FeedService` em `NoteServiceImpl`, `FlameServiceImpl`, `CommentServiceImpl` e `UserServiceImpl`
- Fan-out assíncrono com `@Async` + `@Transactional` para eventos de inserção, recebendo IDs para evitar entidades detached
- Limpeza de eventos delegada ao banco via `ON DELETE CASCADE` para deleção de notas, chamas e comentários
- Limpeza de eventos via handlers para: unfollow, nota oculta e alteração de privacidade de perfil
- Filtro de eventos por tipo via `JpaSpecificationExecutor` e query param `events`
- Remoção do endpoint e métodos legados `getAllFollowedUsersNotes` e `findAllForUserFeed`
- Migration `V20260529__create_table_feed.sql` com índice composto `(recipient_id, created_at DESC)`
- Mock de `FeedService` adicionado em `UserRelationshipTest`

### Necessidade
O feed anterior era uma consulta simples de notas de usuários seguidos, sem suporte a múltiplos tipos de evento e sem possibilidade de filtragem. A nova implementação resolve essas limitações e estabelece a base para eventos futuros.

### Teste manual
1. Criar usuários A, B e C onde A segue B e B segue A (mútuos) e C segue B sem B seguir C
2. Logar como B, criar uma nota, dar flame e comentar em uma nota — verificar que A recebe os eventos no feed e C não recebe (B privado) ou recebe (B público)
3. B alterar perfil para privado — verificar que C perde os eventos de B no feed e A mantém
4. B desseguir A — verificar que A perde todos os eventos de B no feed
5. B seguir C e depois desseguir — verificar que o evento "B seguiu C" some do feed de A
6. Logar como A, aplicar filtro `events=Note_Created` — verificar que apenas eventos de nota criada são retornados
7. Deletar uma nota de B — verificar que os eventos relacionados somem do feed de A
8. Ocultar uma nota de B — verificar que os eventos relacionados somem do feed de A

### Checklist
- [x] Código segue o padrão do projeto
- [x] Documentação atualizada
- [x] Testes adicionados/atualizados

### Breaking Changes
- Endpoint `GET /api/v1/notes/private/following` removido — substituído por `GET /api/v1/feed`
- `DetailCommentRES` passou a incluir o campo `note`, o que pode impactar consumers que dependiam da estrutura anterior