### PR TITLE
refactor(follow): extract follow domain and replace user_follows with dedicated follows table

### DIFF
--- a/src/main/java/br/com/notehub/application/controller/follow/FollowController.java
+++ b/src/main/java/br/com/notehub/application/controller/follow/FollowController.java
@@ -1,0 +1,149 @@
+package br.com.notehub.application.controller.follow;
+
+import br.com.notehub.application.dto.response.page.PageRES;
+import br.com.notehub.application.dto.response.user.DetailUserRES;
+import br.com.notehub.domain.follow.FollowService;
+import com.auth0.jwt.JWT;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Set;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/v1/users")
+@SecurityRequirement(name = "bearer-key")
+@Tag(name = "Follow System Controller", description = "Endpoints for managing follow service")
+@RequiredArgsConstructor
+public class FollowController {
+
+    private final FollowService service;
+
+    private UUID getSubject(String bearerToken) {
+        if (bearerToken == null) return null;
+        String idFromToken = JWT.decode(bearerToken.replace("Bearer ", "")).getSubject();
+        return UUID.fromString(idFromToken);
+    }
+
+    @Operation(summary = "Follow a user.", description = "Allows the requesting user to follow the specified user.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "User followed successfully."),
+            @ApiResponse(responseCode = "403", description = "Invalid token.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
+    })
+    @PostMapping("/{username}/follow")
+    public ResponseEntity<Void> followUser(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
+            @PathVariable("username") String userToFollow
+    ) {
+        UUID idFromToken = getSubject(accessToken);
+        service.follow(idFromToken, userToFollow);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @Operation(summary = "Unfollow a user.", description = "Allows the requesting user to unfollow the specified user.")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "User unfollowed successfully."),
+            @ApiResponse(responseCode = "403", description = "Invalid token.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "404", description = "User not found", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
+    })
+    @DeleteMapping("/{username}/unfollow")
+    public ResponseEntity<Void> unfollowUser(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
+            @PathVariable("username") String userToFollow
+    ) {
+        UUID idFromToken = getSubject(accessToken);
+        service.unfollow(idFromToken, userToFollow);
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
+    }
+
+    @Operation(
+            summary = "Fetches a paginated list of users that the specified user is following.",
+            description = """
+                    Retrieves a page of users a specified user is following,
+                    The requesting user must have permission to view the requested user's following list
+                    (for private accounts, the requested user must follow the requesting user)."""
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Following users page retrieved successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid pageable criteria.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "403", description = "Access denied due to invalid token or insufficient permissions.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "404", description = "User not found.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
+    })
+    @GetMapping("/{username}/following")
+    public ResponseEntity<PageRES<DetailUserRES>> getFollowing(
+            @Parameter(hidden = true) @RequestHeader(required = false, value = "Authorization") String accessToken,
+            @ParameterObject @PageableDefault(page = 0, size = 25, sort = {"followersCount"}, direction = Sort.Direction.DESC) Pageable pageable,
+            @PathVariable("username") String username,
+            @RequestParam(required = false) String q
+    ) {
+        UUID idFromToken = getSubject(accessToken);
+        Page<DetailUserRES> page = service.getUserFollowing(pageable, q, idFromToken, username).map(DetailUserRES::new);
+        return ResponseEntity.status(HttpStatus.OK).body(new PageRES<>(page));
+    }
+
+    @Operation(
+            summary = "Fetches a paginated list of users that are following the specified user.",
+            description = """
+                    Retrieve a page of users following a specified user.
+                    The requesting user must have permission to view the requested user's followers list
+                    (for private accounts, the requested user must follow the requesting user)."""
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "Followers page retrieved successfully."),
+            @ApiResponse(responseCode = "400", description = "Invalid pageable criteria.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "403", description = "Access denied due to invalid token or insufficient permissions.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "404", description = "User not found.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
+    })
+    @GetMapping("/{username}/followers")
+    public ResponseEntity<PageRES<DetailUserRES>> getFollowers(
+            @Parameter(hidden = true) @RequestHeader(required = false, value = "Authorization") String accessToken,
+            @ParameterObject @PageableDefault(page = 0, size = 25, sort = {"followersCount"}, direction = Sort.Direction.DESC) Pageable pageable,
+            @PathVariable("username") String username,
+            @RequestParam(required = false) String q
+    ) {
+        UUID idFromToken = getSubject(accessToken);
+        Page<DetailUserRES> page = service.getUserFollowers(pageable, q, idFromToken, username).map(DetailUserRES::new);
+        return ResponseEntity.status(HttpStatus.OK).body(new PageRES<>(page));
+    }
+
+    @Operation(
+            summary = "Get user mutual connections",
+            description = """
+                    Retrieves a list of usernames that has mutual following with current user."
+                    This includes users that the current user follows and who also follow the current user."""
+    )
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "User mutual connections retrieved successfully."),
+            @ApiResponse(responseCode = "403", description = "Access denied due to invalid token.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "404", description = "User not found.", content = @Content(examples = {})),
+            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
+    })
+    @GetMapping("/mutuals")
+    public ResponseEntity<Set<String>> getMutualConnections(
+            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken
+    ) {
+        UUID idFromToken = getSubject(accessToken);
+        Set<String> mutuals = service.getUserMutualConnections(idFromToken);
+        return ResponseEntity.status(HttpStatus.OK).body(mutuals);
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/controller/user/UserController.java
+++ b/src/main/java/br/com/notehub/application/controller/user/UserController.java
@@ -25,8 +25,6 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.annotations.ParameterObject;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.web.PageableDefault;
@@ -45,9 +43,6 @@ import java.util.UUID;
 @Tag(name = "User Controller", description = "Endpoints for managing users")
 @RequiredArgsConstructor
 public class UserController {
-
-    @Value("${api.client.host}")
-    private String client;
 
     private final UserService service;
     private final TokenService tokenService;
@@ -267,40 +262,6 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
-    @Operation(summary = "Follow a user.", description = "Allows the requesting user to follow the specified user.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "User followed successfully."),
-            @ApiResponse(responseCode = "403", description = "Invalid token.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "404", description = "User not found", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
-    })
-    @PostMapping("/{username}/follow")
-    public ResponseEntity<Void> followUser(
-            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
-            @PathVariable("username") String userToFollow
-    ) {
-        UUID idFromToken = getSubject(accessToken);
-        service.follow(idFromToken, userToFollow);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
-    @Operation(summary = "Unfollow a user.", description = "Allows the requesting user to unfollow the specified user.")
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "204", description = "User unfollowed successfully."),
-            @ApiResponse(responseCode = "403", description = "Invalid token.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "404", description = "User not found", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
-    })
-    @DeleteMapping("/{username}/unfollow")
-    public ResponseEntity<Void> unfollowUser(
-            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken,
-            @PathVariable("username") String userToFollow
-    ) {
-        UUID idFromToken = getSubject(accessToken);
-        service.unfollow(idFromToken, userToFollow);
-        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
-    }
-
     @Operation(summary = "Delete user account", description = "Deletes the user's account.")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "User account deleted successfully."),
@@ -391,79 +352,6 @@ public class UserController {
     ) {
         User user = service.getUser(username);
         return ResponseEntity.status(HttpStatus.OK).body(new DetailUserRES(user));
-    }
-
-    @Operation(
-            summary = "Fetches a paginated list of users that the specified user is following.",
-            description = """
-                    Retrieves a page of users a specified user is following,
-                    The requesting user must have permission to view the requested user's following list
-                    (for private accounts, the requested user must follow the requesting user)."""
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Following users page retrieved successfully."),
-            @ApiResponse(responseCode = "400", description = "Invalid pageable criteria.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "403", description = "Access denied due to invalid token or insufficient permissions.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "404", description = "User not found.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
-    })
-    @GetMapping("/{username}/following")
-    public ResponseEntity<PageRES<DetailUserRES>> getFollowing(
-            @Parameter(hidden = true) @RequestHeader(required = false, value = "Authorization") String accessToken,
-            @ParameterObject @PageableDefault(page = 0, size = 25, sort = {"followersCount"}, direction = Sort.Direction.DESC) Pageable pageable,
-            @PathVariable("username") String username,
-            @RequestParam(required = false) String q
-    ) {
-        UUID idFromToken = getSubject(accessToken);
-        Page<DetailUserRES> page = service.getUserFollowing(pageable, q, idFromToken, username).map(DetailUserRES::new);
-        return ResponseEntity.status(HttpStatus.OK).body(new PageRES<>(page));
-    }
-
-    @Operation(
-            summary = "Fetches a paginated list of users that are following the specified user.",
-            description = """
-                    Retrieve a page of users following a specified user.
-                    The requesting user must have permission to view the requested user's followers list
-                    (for private accounts, the requested user must follow the requesting user)."""
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "Followers page retrieved successfully."),
-            @ApiResponse(responseCode = "400", description = "Invalid pageable criteria.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "403", description = "Access denied due to invalid token or insufficient permissions.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "404", description = "User not found.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
-    })
-    @GetMapping("/{username}/followers")
-    public ResponseEntity<PageRES<DetailUserRES>> getFollowers(
-            @Parameter(hidden = true) @RequestHeader(required = false, value = "Authorization") String accessToken,
-            @ParameterObject @PageableDefault(page = 0, size = 25, sort = {"followersCount"}, direction = Sort.Direction.DESC) Pageable pageable,
-            @PathVariable("username") String username,
-            @RequestParam(required = false) String q
-    ) {
-        UUID idFromToken = getSubject(accessToken);
-        Page<DetailUserRES> page = service.getUserFollowers(pageable, q, idFromToken, username).map(DetailUserRES::new);
-        return ResponseEntity.status(HttpStatus.OK).body(new PageRES<>(page));
-    }
-
-    @Operation(
-            summary = "Get user mutual connections",
-            description = """
-                    Retrieves a list of usernames that has mutual following with current user."
-                    This includes users that the current user follows and who also follow the current user."""
-    )
-    @ApiResponses(value = {
-            @ApiResponse(responseCode = "200", description = "User mutual connections retrieved successfully."),
-            @ApiResponse(responseCode = "403", description = "Access denied due to invalid token.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "404", description = "User not found.", content = @Content(examples = {})),
-            @ApiResponse(responseCode = "500", description = "Internal server error.", content = @Content(examples = {}))
-    })
-    @GetMapping("/mutuals")
-    public ResponseEntity<Set<String>> getMutualConnections(
-            @Parameter(hidden = true) @RequestHeader("Authorization") String accessToken
-    ) {
-        UUID idFromToken = getSubject(accessToken);
-        Set<String> mutuals = service.getUserMutualConnections(idFromToken);
-        return ResponseEntity.status(HttpStatus.OK).body(mutuals);
     }
 
     @Operation(summary = "Get user display name history", description = "Retrieves the history of display names for a user by their username.")

--- a/src/main/java/br/com/notehub/application/counter/Counter.java
+++ b/src/main/java/br/com/notehub/application/counter/Counter.java
@@ -29,18 +29,24 @@ public class Counter {
 
     public void updateFollowersAndFollowingCount(User follower, User following, boolean increment) {
         if (increment) {
-            follower.getFollowing().add(following);
             follower.setFollowingCount(follower.getFollowingCount() + 1);
-            following.getFollowers().add(follower);
             following.setFollowersCount(following.getFollowersCount() + 1);
         } else {
-            follower.getFollowing().remove(following);
             follower.setFollowingCount(follower.getFollowingCount() - 1);
-            following.getFollowers().remove(follower);
             following.setFollowersCount(following.getFollowersCount() - 1);
         }
         userRepository.save(follower);
         userRepository.save(following);
+    }
+
+    public void decrementFollowerCount(User following) {
+        following.setFollowersCount(following.getFollowersCount() - 1);
+        userRepository.save(following);
+    }
+
+    public void decrementFollowingCount(User follower) {
+        follower.setFollowingCount(follower.getFollowingCount() - 1);
+        userRepository.save(follower);
     }
 
     public void updateCommentsCount(Note note, boolean increment) {

--- a/src/main/java/br/com/notehub/application/events/follow/FollowEventListener.java
+++ b/src/main/java/br/com/notehub/application/events/follow/FollowEventListener.java
@@ -1,0 +1,39 @@
+package br.com.notehub.application.events.follow;
+
+import br.com.notehub.application.counter.Counter;
+import br.com.notehub.domain.follow.events.UserDeletedEvent;
+import br.com.notehub.domain.user.User;
+import br.com.notehub.domain.user.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import java.util.UUID;
+
+@Component
+@RequiredArgsConstructor
+public class FollowEventListener {
+
+    private final UserRepository userRepository;
+    private final Counter counter;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void onUserDelete(UserDeletedEvent event) {
+        for (UUID id : event.followerIds()) {
+            User follower = userRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+            counter.decrementFollowingCount(follower);
+        }
+        for (UUID id : event.followingIds()) {
+            User following = userRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+            counter.decrementFollowerCount(following);
+        }
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/implementation/comment/CommentServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/comment/CommentServiceImpl.java
@@ -10,6 +10,7 @@ import br.com.notehub.domain.comment.Comment;
 import br.com.notehub.domain.comment.CommentRepository;
 import br.com.notehub.domain.comment.CommentService;
 import br.com.notehub.domain.feed.FeedService;
+import br.com.notehub.domain.follow.FollowService;
 import br.com.notehub.domain.note.Note;
 import br.com.notehub.domain.note.NoteRepository;
 import br.com.notehub.domain.notification.NotificationService;
@@ -35,6 +36,7 @@ public class CommentServiceImpl implements CommentService {
     private final UserRepository userRepository;
     private final NoteRepository noteRepository;
     private final CommentRepository repository;
+    private final FollowService followService;
     private final NotificationService notifier;
     private final Counter counter;
     private final FeedService feeder;
@@ -43,16 +45,6 @@ public class CommentServiceImpl implements CommentService {
         if (idFromToken == null) throw new AccessDeniedException("Usuário sem permissão.");
         if (!Objects.equals(idFromToken, idFromRequested)) {
             throw new AccessDeniedException("Usuário sem permissão.");
-        }
-    }
-
-    private void validateBidirectionalFollowAccess(@Nullable User requesting, User requested) {
-        if (requesting == null) throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
-        boolean isSameUser = Objects.equals(requesting.getUsername(), requested.getUsername());
-        boolean requestedContainsRequesting = requested.getFollowing().contains(requesting);
-        boolean requestingContainsRequested = requesting.getFollowing().contains(requested);
-        if (!isSameUser && (!requestedContainsRequesting || !requestingContainsRequested)) {
-            throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
         }
     }
 
@@ -107,7 +99,7 @@ public class CommentServiceImpl implements CommentService {
         User author = requested.getUser();
         if (author != null) {
             if (requested.isHidden()) validateAccess(idFromToken, author.getId());
-            if (author.isProfilePrivate()) validateBidirectionalFollowAccess(requesting, author);
+            if (author.isProfilePrivate()) followService.validateBidirectionalFollowAccess(requesting, author);
         }
         Page<DetailCommentRES> page = repository.findAllByNoteId(pageable, requested.getId()).map(DetailCommentRES::new);
         return new PageRES<>(page);

--- a/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/feed/FeedServiceImpl.java
@@ -7,6 +7,8 @@ import br.com.notehub.domain.comment.CommentRepository;
 import br.com.notehub.domain.feed.*;
 import br.com.notehub.domain.flame.Flame;
 import br.com.notehub.domain.flame.FlameRepository;
+import br.com.notehub.domain.follow.Follow;
+import br.com.notehub.domain.follow.FollowRepository;
 import br.com.notehub.domain.note.Note;
 import br.com.notehub.domain.note.NoteRepository;
 import br.com.notehub.domain.user.User;
@@ -30,15 +32,17 @@ public class FeedServiceImpl implements FeedService {
 
     private final FeedRepository repository;
     private final UserRepository userRepository;
+    private final FollowRepository followRepository;
     private final NoteRepository noteRepository;
     private final FlameRepository flameRepository;
     private final CommentRepository commentRepository;
 
     private boolean canSeeProfile(User requesting, User requested) {
-        if (!requested.isProfilePrivate()) return true;
-        boolean requestedContainsRequesting = requested.getFollowing().contains(requesting);
-        boolean requestingContainsRequested = requesting.getFollowing().contains(requested);
-        return requestingContainsRequested && requestedContainsRequesting;
+        UUID requestingId = requesting.getId();
+        UUID requestedId = requested.getId();
+        boolean requestedFollowsRequesting = followRepository.existsByFollowerIdAndFollowingId(requestedId, requestingId);
+        boolean requestingFollowsRequested = followRepository.existsByFollowerIdAndFollowingId(requestingId, requestedId);
+        return requestedFollowsRequesting && requestingFollowsRequested;
     }
 
     private boolean canSeeNote(Note note, Flame flame, Comment comment) {
@@ -49,7 +53,9 @@ public class FeedServiceImpl implements FeedService {
     }
 
     private void fanOut(FeedEvent event, User actor, User related, Note note, Flame flame, Comment comment) {
-        Set<User> followers = actor.getFollowers();
+        Set<User> followers = followRepository.findByFollowingId(actor.getId(), Pageable.unpaged())
+                .map(Follow::getFollower)
+                .toSet();
         List<Feed> events = followers.stream()
                 .filter(f -> canSeeProfile(actor, f))
                 .filter(f -> canSeeNote(note, flame, comment))

--- a/src/main/java/br/com/notehub/application/implementation/flame/FlameServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/flame/FlameServiceImpl.java
@@ -8,22 +8,20 @@ import br.com.notehub.domain.feed.FeedService;
 import br.com.notehub.domain.flame.Flame;
 import br.com.notehub.domain.flame.FlameRepository;
 import br.com.notehub.domain.flame.FlameService;
+import br.com.notehub.domain.follow.FollowService;
 import br.com.notehub.domain.note.Note;
 import br.com.notehub.domain.note.NoteRepository;
 import br.com.notehub.domain.notification.NotificationService;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserRepository;
-import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.Objects;
 import java.util.UUID;
 
 @Component
@@ -33,20 +31,10 @@ public class FlameServiceImpl implements FlameService {
     private final UserRepository userRepository;
     private final NoteRepository noteRepository;
     private final FlameRepository repository;
+    private final FollowService followService;
     private final NotificationService notifier;
     private final Counter counter;
     private final FeedService feeder;
-
-    private void validateBidirectionalFollowAccess(@Nullable User requesting, User requested) {
-        if (!requested.isProfilePrivate()) return;
-        if (requesting == null) throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
-        boolean isSameUser = Objects.equals(requesting.getUsername(), requested.getUsername());
-        boolean requestedContainsRequesting = requested.getFollowing().contains(requesting);
-        boolean requestingContainsRequested = requesting.getFollowing().contains(requested);
-        if (!isSameUser && (!requestedContainsRequesting || !requestingContainsRequested)) {
-            throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
-        }
-    }
 
     @Transactional
     @Override
@@ -74,7 +62,7 @@ public class FlameServiceImpl implements FlameService {
     public PageRES<DetailFlameRES> getUserFlames(UUID userIdFromToken, Pageable pageable, String username, String q) {
         User requesting = (userIdFromToken != null) ? userRepository.findById(userIdFromToken).orElseThrow(EntityNotFoundException::new) : null;
         User requested = userRepository.findByUsername(username).orElseThrow(EntityNotFoundException::new);
-        validateBidirectionalFollowAccess(requesting, requested);
+        followService.validateBidirectionalFollowAccess(requesting, requested);
         Page<DetailFlameRES> page = repository.getUserFlames(pageable, username, q).map(DetailFlameRES::new);
         return new PageRES<>(page);
     }

--- a/src/main/java/br/com/notehub/application/implementation/follow/FollowServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/follow/FollowServiceImpl.java
@@ -1,0 +1,137 @@
+package br.com.notehub.application.implementation.follow;
+
+import br.com.notehub.application.counter.Counter;
+import br.com.notehub.application.dto.notification.MessageNotification;
+import br.com.notehub.domain.feed.FeedService;
+import br.com.notehub.domain.follow.Follow;
+import br.com.notehub.domain.follow.FollowRepository;
+import br.com.notehub.domain.follow.FollowService;
+import br.com.notehub.domain.notification.NotificationService;
+import br.com.notehub.domain.user.User;
+import br.com.notehub.domain.user.UserRepository;
+import jakarta.annotation.Nullable;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import static br.com.notehub.infra.exception.CustomExceptions.*;
+
+@Component
+@RequiredArgsConstructor
+public class FollowServiceImpl implements FollowService {
+
+    private final UserRepository userRepository;
+    private final FollowRepository repository;
+    private final Counter counter;
+    private final NotificationService notifier;
+    private final FeedService feeder;
+
+    private User findUser(UUID id) {
+        return userRepository.findById(id).orElseThrow(EntityNotFoundException::new);
+    }
+
+    private User findUser(String username) {
+        return userRepository.findByUsername(username).orElseThrow(EntityNotFoundException::new);
+    }
+
+    private boolean isSameUser(UUID followerId, UUID followingId) {
+        return Objects.equals(followerId, followingId);
+    }
+
+    private boolean areMutuals(UUID requesting, UUID requested) {
+        boolean requestedFollowsRequesting = repository.existsByFollowerIdAndFollowingId(requested, requesting);
+        boolean requestingFollowsRequested = repository.existsByFollowerIdAndFollowingId(requesting, requested);
+        return requestedFollowsRequesting && requestingFollowsRequested;
+    }
+
+    @Override
+    public void validateBidirectionalFollowAccess(@Nullable User requesting, User requested) {
+        if (!requested.isProfilePrivate()) return;
+        if (requesting == null) throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
+        if (!isSameUser(requesting.getId(), requested.getId()) && !areMutuals(requesting.getId(), requested.getId())) {
+            throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
+        }
+    }
+
+    @Override
+    public void follow(UUID followerId, String username) {
+        User follower = findUser(followerId);
+        User following = findUser(username);
+        if (Objects.equals(follower.getId(), following.getId())) throw new SelfFollowException();
+        if (repository.existsByFollowerIdAndFollowingId(follower.getId(), following.getId())) throw new AlreadyFollowingException();
+        repository.save(new Follow(follower, following));
+        counter.updateFollowersAndFollowingCount(follower, following, true);
+        notifier.notify(follower, following, follower, MessageNotification.of(follower));
+        feeder.onUserFollowed(follower.getId(), following.getId());
+    }
+
+    @Override
+    public void unfollow(UUID followerId, String username) {
+        User follower = findUser(followerId);
+        User following = findUser(username);
+        if (!repository.existsByFollowerIdAndFollowingId(follower.getId(), following.getId())) throw new NotFollowingException();
+        repository.deleteByFollowerIdAndFollowingId(follower.getId(), following.getId());
+        counter.updateFollowersAndFollowingCount(follower, following, false);
+        feeder.onUserUnfollowed(follower.getId(), following.getId());
+    }
+
+    @Override
+    public Page<User> getUserFollowing(Pageable pageable, String q, UUID requestingId, String username) {
+        User requesting = (requestingId != null) ? findUser(requestingId) : null;
+        User requested = findUser(username);
+        validateBidirectionalFollowAccess(requesting, requested);
+        List<UUID> ids = repository.findByFollowerId(requested.getId(), Pageable.unpaged())
+                .map(f -> f.getFollowing().getId())
+                .toList();
+        return userRepository.findAllByIdIn(pageable, q, ids);
+    }
+
+    @Override
+    public Page<User> getUserFollowers(Pageable pageable, String q, UUID requestingId, String username) {
+        User requesting = (requestingId != null) ? findUser(requestingId) : null;
+        User requested = findUser(username);
+        validateBidirectionalFollowAccess(requesting, requested);
+        List<UUID> ids = repository.findByFollowingId(requested.getId(), Pageable.unpaged())
+                .map(f -> f.getFollower().getId())
+                .toList();
+        return userRepository.findAllByIdIn(pageable, q, ids);
+    }
+
+    @Override
+    public Set<String> getUserMutualConnections(UUID id) {
+        Set<UUID> following = repository.findByFollowerId(id, Pageable.unpaged())
+                .map(f -> f.getFollowing().getId())
+                .toSet();
+        Set<UUID> followers = repository.findByFollowingId(id, Pageable.unpaged())
+                .map(f -> f.getFollower().getId())
+                .toSet();
+        following.retainAll(followers);
+        return userRepository.findAllById(following).stream()
+                .map(User::getUsername)
+                .collect(Collectors.toSet());
+    }
+
+    @Override
+    public Set<UUID> getUserFollowersId(UUID id) {
+        return repository.findByFollowingId(id, Pageable.unpaged())
+                .map(f -> f.getFollower().getId())
+                .toSet();
+    }
+
+    @Override
+    public Set<UUID> getUserFollowingId(UUID id) {
+        return repository.findByFollowerId(id, Pageable.unpaged())
+                .map(f -> f.getFollowing().getId())
+                .toSet();
+    }
+
+}

--- a/src/main/java/br/com/notehub/application/implementation/follow/FollowServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/follow/FollowServiceImpl.java
@@ -18,10 +18,7 @@ import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.stream.Collectors;
 
 import static br.com.notehub.infra.exception.CustomExceptions.*;
@@ -111,12 +108,12 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public Set<String> getUserMutualConnections(UUID id) {
-        Set<UUID> following = repository.findByFollowerId(id, Pageable.unpaged())
+        Set<UUID> following = new HashSet<>(repository.findByFollowerId(id, Pageable.unpaged())
                 .map(f -> f.getFollowing().getId())
-                .toSet();
-        Set<UUID> followers = repository.findByFollowingId(id, Pageable.unpaged())
+                .toSet());
+        Set<UUID> followers = new HashSet<>(repository.findByFollowingId(id, Pageable.unpaged())
                 .map(f -> f.getFollower().getId())
-                .toSet();
+                .toSet());
         following.retainAll(followers);
         return userRepository.findAllById(following).stream()
                 .map(User::getUsername)

--- a/src/main/java/br/com/notehub/application/implementation/follow/FollowServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/follow/FollowServiceImpl.java
@@ -16,6 +16,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Objects;
@@ -62,6 +63,7 @@ public class FollowServiceImpl implements FollowService {
         }
     }
 
+    @Transactional
     @Override
     public void follow(UUID followerId, String username) {
         User follower = findUser(followerId);
@@ -74,6 +76,7 @@ public class FollowServiceImpl implements FollowService {
         feeder.onUserFollowed(follower.getId(), following.getId());
     }
 
+    @Transactional
     @Override
     public void unfollow(UUID followerId, String username) {
         User follower = findUser(followerId);
@@ -122,16 +125,12 @@ public class FollowServiceImpl implements FollowService {
 
     @Override
     public Set<UUID> getUserFollowersId(UUID id) {
-        return repository.findByFollowingId(id, Pageable.unpaged())
-                .map(f -> f.getFollower().getId())
-                .toSet();
+        return repository.findFollowerIdsByFollowingId(id);
     }
 
     @Override
     public Set<UUID> getUserFollowingId(UUID id) {
-        return repository.findByFollowerId(id, Pageable.unpaged())
-                .map(f -> f.getFollowing().getId())
-                .toSet();
+        return repository.findFollowingIdsByFollowerId(id);
     }
 
 }

--- a/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/note/NoteServiceImpl.java
@@ -6,6 +6,7 @@ import br.com.notehub.application.dto.response.note.DetailNoteRES;
 import br.com.notehub.application.dto.response.note.LowDetailNoteRES;
 import br.com.notehub.application.dto.response.page.PageRES;
 import br.com.notehub.domain.feed.FeedService;
+import br.com.notehub.domain.follow.FollowService;
 import br.com.notehub.domain.note.Note;
 import br.com.notehub.domain.note.NoteRepository;
 import br.com.notehub.domain.note.NoteService;
@@ -36,6 +37,7 @@ public class NoteServiceImpl implements NoteService {
     private final UserRepository userRepository;
     private final TagRepository tagRepository;
     private final NoteRepository repository;
+    private final FollowService followService;
     private final Counter counter;
     private final FeedService feeder;
 
@@ -43,16 +45,6 @@ public class NoteServiceImpl implements NoteService {
         if (idFromToken == null) throw new AccessDeniedException("Usuário sem permissão.");
         if (!Objects.equals(idFromToken, idFromRequested)) {
             throw new AccessDeniedException("Usuário sem permissão.");
-        }
-    }
-
-    private void validateBidirectionalFollowAccess(@Nullable User requesting, User requested) {
-        if (requesting == null) throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
-        boolean isSameUser = Objects.equals(requesting.getUsername(), requested.getUsername());
-        boolean requestedContainsRequesting = requested.getFollowing().contains(requesting);
-        boolean requestingContainsRequested = requesting.getFollowing().contains(requested);
-        if (!isSameUser && (!requestedContainsRequesting || !requestingContainsRequested)) {
-            throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
         }
     }
 
@@ -195,7 +187,7 @@ public class NoteServiceImpl implements NoteService {
     public List<String> getAllPublicUserTags(UUID idFromToken, String username) {
         User requesting = (idFromToken != null) ? userRepository.findById(idFromToken).orElseThrow(EntityNotFoundException::new) : null;
         User requested = userRepository.findByUsername(username).orElseThrow(EntityNotFoundException::new);
-        if (requested.isProfilePrivate()) validateBidirectionalFollowAccess(requesting, requested);
+        if (requested.isProfilePrivate()) followService.validateBidirectionalFollowAccess(requesting, requested);
         return tagRepository.findAllByNotesUserUsernameAndNotesHiddenFalseOrderByNameAsc(username).stream().map(Tag::getName).toList();
     }
 
@@ -234,7 +226,7 @@ public class NoteServiceImpl implements NoteService {
         User requesting = (idFromToken != null) ? userRepository.findById(idFromToken).orElseThrow(EntityNotFoundException::new) : null;
         User requested = userRepository.findByUsername(username).orElseThrow(EntityNotFoundException::new);
         if (Objects.equals(type, "hidden")) validateAccess(idFromToken, requested.getId());
-        if (requested.isProfilePrivate()) validateBidirectionalFollowAccess(requesting, requested);
+        if (requested.isProfilePrivate()) followService.validateBidirectionalFollowAccess(requesting, requested);
         Page<LowDetailNoteRES> page = repository.searchUserNotesBySpecs(pageable, username, q, tag, type).map(LowDetailNoteRES::new);
         return new PageRES<>(page);
     }
@@ -247,7 +239,7 @@ public class NoteServiceImpl implements NoteService {
         User author = requested.getUser();
         if (author != null) {
             if (requested.isHidden()) validateAccess(idFromToken, author.getId());
-            if (author.isProfilePrivate()) validateBidirectionalFollowAccess(requesting, author);
+            if (author.isProfilePrivate()) followService.validateBidirectionalFollowAccess(requesting, author);
         }
         return new DetailNoteRES(requested);
     }
@@ -267,9 +259,9 @@ public class NoteServiceImpl implements NoteService {
 
     @Override
     public PageRES<LowDetailNoteRES> getAllFollowedUserNotes(Pageable pageable, UUID idFromToken, String username) {
-        User requesting = userRepository.findByIdWithFollowersAndFollowing(idFromToken).orElseThrow(EntityNotFoundException::new);
-        User requested = userRepository.findByUsernameWithFollowersAndFollowing(username).orElseThrow(EntityNotFoundException::new);
-        if (requested.isProfilePrivate()) validateBidirectionalFollowAccess(requesting, requested);
+        User requesting = userRepository.findById(idFromToken).orElseThrow(EntityNotFoundException::new);
+        User requested = userRepository.findByUsername(username).orElseThrow(EntityNotFoundException::new);
+        if (requested.isProfilePrivate()) followService.validateBidirectionalFollowAccess(requesting, requested);
         Page<LowDetailNoteRES> page = repository.findAllByUserUsernameAndHiddenFalse(pageable, username).map(LowDetailNoteRES::new);
         return new PageRES<>(page);
     }

--- a/src/main/java/br/com/notehub/application/implementation/reply/ReplyServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/reply/ReplyServiceImpl.java
@@ -8,6 +8,7 @@ import br.com.notehub.application.dto.response.reply.CreateReplyRES;
 import br.com.notehub.application.dto.response.reply.DetailReplyRES;
 import br.com.notehub.domain.comment.Comment;
 import br.com.notehub.domain.comment.CommentRepository;
+import br.com.notehub.domain.follow.FollowService;
 import br.com.notehub.domain.note.Note;
 import br.com.notehub.domain.notification.NotificationService;
 import br.com.notehub.domain.reply.Reply;
@@ -35,6 +36,7 @@ public class ReplyServiceImpl implements ReplyService {
     private final UserRepository userRepository;
     private final CommentRepository commentRepository;
     private final ReplyRepository repository;
+    private final FollowService followService;
     private final NotificationService notifier;
     private final Counter counter;
 
@@ -42,16 +44,6 @@ public class ReplyServiceImpl implements ReplyService {
         if (idFromToken == null) throw new AccessDeniedException("Usuário sem permissão.");
         if (!Objects.equals(idFromToken, idFromRequested)) {
             throw new AccessDeniedException("Usuário sem permissão.");
-        }
-    }
-
-    private void validateBidirectionalFollowAccess(@Nullable User requesting, User requested) {
-        if (requesting == null) throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
-        boolean isSameUser = Objects.equals(requesting.getUsername(), requested.getUsername());
-        boolean requestedContainsRequesting = requested.getFollowing().contains(requesting);
-        boolean requestingContainsRequested = requesting.getFollowing().contains(requested);
-        if (!isSameUser && (!requestedContainsRequesting || !requestingContainsRequested)) {
-            throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
         }
     }
 
@@ -121,7 +113,7 @@ public class ReplyServiceImpl implements ReplyService {
         User author = requested.getUser();
         if (author != null) {
             if (requested.isHidden()) validateAccess(idFromToken, author.getId());
-            if (author.isProfilePrivate()) validateBidirectionalFollowAccess(requesting, author);
+            if (author.isProfilePrivate()) followService.validateBidirectionalFollowAccess(requesting, author);
         }
         Page<DetailReplyRES> page = repository.findAllByCommentId(pageable, commentIdFromPath).map(DetailReplyRES::new);
         return new PageRES<>(page);

--- a/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
+++ b/src/main/java/br/com/notehub/application/implementation/user/UserServiceImpl.java
@@ -1,24 +1,22 @@
 package br.com.notehub.application.implementation.user;
 
-import br.com.notehub.application.counter.Counter;
-import br.com.notehub.application.dto.notification.MessageNotification;
 import br.com.notehub.domain.feed.FeedService;
+import br.com.notehub.domain.follow.FollowService;
+import br.com.notehub.domain.follow.events.UserDeletedEvent;
 import br.com.notehub.domain.history.UserHistoryService;
 import br.com.notehub.domain.note.NoteService;
-import br.com.notehub.domain.notification.NotificationService;
 import br.com.notehub.domain.token.TokenService;
 import br.com.notehub.domain.user.Subscription;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserRepository;
 import br.com.notehub.domain.user.UserService;
-import jakarta.annotation.Nullable;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -32,7 +30,6 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import static br.com.notehub.infra.exception.CustomExceptions.*;
 
@@ -41,12 +38,12 @@ import static br.com.notehub.infra.exception.CustomExceptions.*;
 public class UserServiceImpl implements UserService {
 
     private final UserRepository repository;
+    private final ApplicationEventPublisher eventPublisher;
     private final UserHistoryService historian;
-    private final NotificationService notifier;
+    private final FollowService followService;
     private final TokenService tokenService;
     private final NoteService noteService;
     private final PasswordEncoder encoder;
-    private final Counter counter;
     private final FeedService feeder;
 
     private void validateGif(User user, String img, String field) {
@@ -93,32 +90,6 @@ public class UserServiceImpl implements UserService {
 
     private void validateActiveField(boolean active) {
         if (!active) throw new EntityNotFoundException();
-    }
-
-    private void validateBidirectionalFollowAccess(@Nullable User requesting, User requested) {
-        if (!requested.isProfilePrivate()) return;
-        if (requesting == null) throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
-        boolean isSameUser = Objects.equals(requesting.getUsername(), requested.getUsername());
-        boolean requestedContainsRequesting = requested.getFollowing().contains(requesting);
-        boolean requestingContainsRequested = requesting.getFollowing().contains(requested);
-        if (!isSameUser && (!requestedContainsRequesting || !requestingContainsRequested)) {
-            throw new AccessDeniedException("Não há vínculo bidirecional entre os usuários.");
-        }
-    }
-
-    private Page<User> getUserConnections(Pageable pageable, String q, UUID userRequestingId, String userRequestedUsername, Function<User, Set<User>> getter) {
-        User requesting = (userRequestingId != null) ? repository.findById(userRequestingId).orElseThrow(EntityNotFoundException::new) : null;
-        User requested = repository.findByUsername(userRequestedUsername).orElseThrow(EntityNotFoundException::new);
-        validateBidirectionalFollowAccess(requesting, requested);
-        List<UUID> ids = getter.apply(requested).stream().map(User::getId).toList();
-        return repository.findAllByIdIn(pageable, q, ids);
-    }
-
-    private boolean isFollowing(User follower, User following) {
-        if (Objects.equals(follower.getId(), following.getId())) {
-            throw new SelfFollowException();
-        }
-        return following.getFollowers().contains(follower);
     }
 
     private Subscription validateSubscription(String subscriptionStr) {
@@ -246,44 +217,16 @@ public class UserServiceImpl implements UserService {
 
     @Transactional
     @Override
-    public void follow(UUID idFromToken, String username) {
-        User follower = repository.findByIdWithFollowersAndFollowing(idFromToken).orElseThrow(EntityNotFoundException::new);
-        User following = repository.findByUsernameWithFollowersAndFollowing(username).orElseThrow(EntityNotFoundException::new);
-        if (isFollowing(follower, following)) throw new AlreadyFollowingException();
-        counter.updateFollowersAndFollowingCount(follower, following, true);
-        notifier.notify(follower, following, follower, MessageNotification.of(follower));
-        feeder.onUserFollowed(follower.getId(), following.getId());
-    }
-
-    @Transactional
-    @Override
-    public void unfollow(UUID idFromToken, String username) {
-        User follower = repository.findByIdWithFollowersAndFollowing(idFromToken).orElseThrow(EntityNotFoundException::new);
-        User following = repository.findByUsernameWithFollowersAndFollowing(username).orElseThrow(EntityNotFoundException::new);
-        if (!isFollowing(follower, following)) throw new NotFollowingException();
-        counter.updateFollowersAndFollowingCount(follower, following, false);
-        feeder.onUserUnfollowed(follower.getId(), following.getId());
-    }
-
-    @Transactional
-    @Override
     public void delete(UUID idFromToken, String password) {
         User user = repository.findById(idFromToken).orElseThrow(EntityNotFoundException::new);
         boolean matches = encoder.matches(password, user.getPassword());
         if (!matches) throw new BadCredentialsException("password");
-        user.getFollowing().forEach(following -> {
-            following.getFollowers().remove(user);
-            following.setFollowersCount(following.getFollowersCount() - 1);
-            repository.save(following);
-        });
-        user.getFollowers().forEach(follower -> {
-            follower.getFollowing().remove(user);
-            follower.setFollowingCount(follower.getFollowingCount() - 1);
-            repository.save(follower);
-        });
         if (user.isProfilePrivate()) noteService.deleteAllUserNotes(user);
         else noteService.deleteAllUserHiddenNotes(user);
+        Set<UUID> followersIds = followService.getUserFollowersId(idFromToken);
+        Set<UUID> followingIds = followService.getUserFollowingId(idFromToken);
         repository.delete(user);
+        eventPublisher.publishEvent(new UserDeletedEvent(followersIds, followingIds));
     }
 
     @Override
@@ -301,27 +244,6 @@ public class UserServiceImpl implements UserService {
     @Override
     public Page<User> findAll(Pageable pageable, String q) {
         return repository.findAllActiveUsersByUsernameOrDisplayName(pageable, q);
-    }
-
-    @Transactional(readOnly = true)
-    @Override
-    public Page<User> getUserFollowing(Pageable pageable, String q, UUID idFromToken, String username) {
-        return getUserConnections(pageable, q, idFromToken, username, User::getFollowing);
-    }
-
-    @Transactional(readOnly = true)
-    @Override
-    public Page<User> getUserFollowers(Pageable pageable, String q, UUID idFromToken, String username) {
-        return getUserConnections(pageable, q, idFromToken, username, User::getFollowers);
-    }
-
-    @Override
-    public Set<String> getUserMutualConnections(UUID id) {
-        User user = repository.findByIdWithFollowersAndFollowing(id).orElseThrow(EntityNotFoundException::new);
-        Set<String> following = user.getFollowing().stream().map(User::getUsername).collect(Collectors.toSet());
-        Set<String> followers = user.getFollowers().stream().map(User::getUsername).collect(Collectors.toSet());
-        following.retainAll(followers);
-        return following;
     }
 
     @Override

--- a/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
+++ b/src/main/java/br/com/notehub/domain/feed/FeedRepository.java
@@ -16,13 +16,17 @@ public interface FeedRepository extends JpaRepository<Feed, UUID>, JpaSpecificat
     @Query("""
             DELETE FROM Feed f
             WHERE f.actor.id = :actorId
-            AND f.recipient.id NOT IN (
-                SELECT f1.id FROM User actor
-                JOIN actor.followers f1
-                JOIN actor.following f2
-                WHERE actor.id = :actorId
-                AND f1.id = f2.id
-            )
+              AND f.recipient.id NOT IN (
+                  SELECT fl1.follower.id
+                  FROM Follow fl1
+                  WHERE fl1.following.id = :actorId
+                    AND EXISTS (
+                        SELECT 1
+                        FROM Follow fl2
+                        WHERE fl2.follower.id = :actorId
+                          AND fl2.following.id = fl1.follower.id
+                    )
+              )
             """)
     void deleteActorEventsForNonMutualFollowers(@Param("actorId") UUID actorId);
 

--- a/src/main/java/br/com/notehub/domain/follow/Follow.java
+++ b/src/main/java/br/com/notehub/domain/follow/Follow.java
@@ -1,0 +1,39 @@
+package br.com.notehub.domain.follow;
+
+import br.com.notehub.domain.user.User;
+import jakarta.persistence.*;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
+
+import java.time.Instant;
+
+@Entity
+@Table(name = "follows")
+@Data
+@NoArgsConstructor
+public class Follow {
+
+    @EmbeddedId
+    private FollowId id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @MapsId("followerId")
+    private User follower;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    @MapsId("followingId")
+    private User following;
+
+    private Instant createdAt = Instant.now();
+
+    public Follow(User follower, User following) {
+        this.id = new FollowId(follower.getId(), following.getId());
+        this.follower = follower;
+        this.following = following;
+    }
+
+}

--- a/src/main/java/br/com/notehub/domain/follow/FollowId.java
+++ b/src/main/java/br/com/notehub/domain/follow/FollowId.java
@@ -1,0 +1,18 @@
+package br.com.notehub.domain.follow;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Embeddable
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowId implements Serializable {
+    private UUID followerId;
+    private UUID followingId;
+}

--- a/src/main/java/br/com/notehub/domain/follow/FollowRepository.java
+++ b/src/main/java/br/com/notehub/domain/follow/FollowRepository.java
@@ -3,14 +3,23 @@ package br.com.notehub.domain.follow;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Set;
 import java.util.UUID;
 
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, FollowId> {
 
     boolean existsByFollowerIdAndFollowingId(UUID followerId, UUID followingId);
+
+    @Query("SELECT f.follower.id FROM Follow f WHERE f.following.id = :id")
+    Set<UUID> findFollowerIdsByFollowingId(@Param("id") UUID followerId);
+
+    @Query("SELECT f.following.id FROM Follow f WHERE f.follower.id = :id")
+    Set<UUID> findFollowingIdsByFollowerId(@Param("id") UUID followingId);
 
     Page<Follow> findByFollowerId(UUID followerId, Pageable pageable);
 

--- a/src/main/java/br/com/notehub/domain/follow/FollowRepository.java
+++ b/src/main/java/br/com/notehub/domain/follow/FollowRepository.java
@@ -1,0 +1,21 @@
+package br.com.notehub.domain.follow;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, FollowId> {
+
+    boolean existsByFollowerIdAndFollowingId(UUID followerId, UUID followingId);
+
+    Page<Follow> findByFollowerId(UUID followerId, Pageable pageable);
+
+    Page<Follow> findByFollowingId(UUID followingId, Pageable pageable);
+
+    void deleteByFollowerIdAndFollowingId(UUID followerId, UUID followingId);
+
+}

--- a/src/main/java/br/com/notehub/domain/follow/FollowService.java
+++ b/src/main/java/br/com/notehub/domain/follow/FollowService.java
@@ -1,0 +1,31 @@
+package br.com.notehub.domain.follow;
+
+import br.com.notehub.domain.user.User;
+import jakarta.annotation.Nullable;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+
+import java.util.Set;
+import java.util.UUID;
+
+@Service
+public interface FollowService {
+
+    void validateBidirectionalFollowAccess(@Nullable User requesting, User requested);
+
+    void follow(UUID followerId, String username);
+
+    void unfollow(UUID followerId, String username);
+
+    Page<User> getUserFollowing(Pageable pageable, String q, UUID requestingId, String username);
+
+    Page<User> getUserFollowers(Pageable pageable, String q, UUID requestingId, String username);
+
+    Set<String> getUserMutualConnections(UUID id);
+
+    Set<UUID> getUserFollowersId(UUID id);
+
+    Set<UUID> getUserFollowingId(UUID id);
+
+}

--- a/src/main/java/br/com/notehub/domain/follow/events/UserDeletedEvent.java
+++ b/src/main/java/br/com/notehub/domain/follow/events/UserDeletedEvent.java
@@ -1,0 +1,10 @@
+package br.com.notehub.domain.follow.events;
+
+import java.util.Set;
+import java.util.UUID;
+
+public record UserDeletedEvent(
+        Set<UUID> followerIds,
+        Set<UUID> followingIds
+) {
+}

--- a/src/main/java/br/com/notehub/domain/user/User.java
+++ b/src/main/java/br/com/notehub/domain/user/User.java
@@ -26,9 +26,9 @@ import java.util.*;
 @Table(name = "users")
 @NoArgsConstructor
 @Data
-@JsonIgnoreProperties({"tokens", "history", "notes", "comments", "replies", "flames", "followers", "following", "receivedNotifications", "sentNotifications", "relatedNotifications"})
-@ToString(exclude = {"tokens", "history", "notes", "comments", "replies", "flames", "followers", "following", "receivedNotifications", "sentNotifications", "relatedNotifications"})
-@EqualsAndHashCode(exclude = {"tokens", "history", "notes", "comments", "replies", "flames", "followers", "following", "receivedNotifications", "sentNotifications", "relatedNotifications"})
+@JsonIgnoreProperties({"tokens", "history", "notes", "comments", "replies", "flames", "receivedNotifications", "sentNotifications", "relatedNotifications"})
+@ToString(exclude = {"tokens", "history", "notes", "comments", "replies", "flames", "receivedNotifications", "sentNotifications", "relatedNotifications"})
+@EqualsAndHashCode(exclude = {"tokens", "history", "notes", "comments", "replies", "flames", "receivedNotifications", "sentNotifications", "relatedNotifications"})
 public class User implements UserDetails {
 
     @Id
@@ -107,17 +107,8 @@ public class User implements UserDetails {
     @OneToMany(mappedBy = "related")
     private List<Notification> relatedNotifications = new ArrayList<>();
 
-    @ManyToMany(fetch = FetchType.LAZY)
-    @JoinTable(
-            name = "user_follows",
-            joinColumns = @JoinColumn(name = "follower_id"),
-            inverseJoinColumns = @JoinColumn(name = "following_id")
-    )
-    private Set<User> following = new HashSet<>();
     private int followingCount = 0;
 
-    @ManyToMany(mappedBy = "following", fetch = FetchType.LAZY)
-    private Set<User> followers = new HashSet<>();
     private int followersCount = 0;
 
     @Override

--- a/src/main/java/br/com/notehub/domain/user/UserRepository.java
+++ b/src/main/java/br/com/notehub/domain/user/UserRepository.java
@@ -2,7 +2,6 @@ package br.com.notehub.domain.user;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -26,15 +25,6 @@ public interface UserRepository extends JpaRepository<User, UUID> {
 
     Optional<User> findByUsername(String username);
 
-    @Query("SELECT u FROM User u LEFT JOIN FETCH u.following WHERE u.id = :id")
-    Optional<User> findByIdWithFollowing(@Param("id") UUID id);
-
-    @Query("SELECT u FROM User u LEFT JOIN FETCH u.followers LEFT JOIN FETCH u.following WHERE u.id = :id")
-    Optional<User> findByIdWithFollowersAndFollowing(@Param("id") UUID id);
-
-    @Query("SELECT u FROM User u LEFT JOIN FETCH u.followers LEFT JOIN FETCH u.following WHERE u.username = :username")
-    Optional<User> findByUsernameWithFollowersAndFollowing(@Param("username") String username);
-
     List<User> findAllByActiveTrue();
 
     @Query("""
@@ -52,14 +42,14 @@ public interface UserRepository extends JpaRepository<User, UUID> {
     @Query("SELECT u FROM User u WHERE u.createdAt < :nowMinus7Days AND u.active = false")
     List<User> findUsersWithExpiredActivationTime(@Param("nowMinus7Days") Instant nowMinus7Days);
 
-    @EntityGraph(attributePaths = {"followers", "following"})
     @Query("""
             SELECT DISTINCT u FROM User u
             WHERE u.id IN :ids
-            AND (
-                :q IS NULL OR LOWER(u.username) LIKE LOWER(CONCAT('%', CAST(:q AS text), '%')) OR
-                :q IS NULL OR LOWER(u.displayName) LIKE LOWER(CONCAT('%', CAST(:q AS text), '%'))
-            )
+              AND (
+                  :q IS NULL
+                  OR LOWER(u.username) LIKE LOWER(CONCAT('%', CAST(:q AS text), '%'))
+                  OR LOWER(u.displayName) LIKE LOWER(CONCAT('%', CAST(:q AS text), '%'))
+              )
             """)
     Page<User> findAllByIdIn(Pageable pageable, @Param("q") String q, @Param("ids") List<UUID> ids);
 

--- a/src/main/java/br/com/notehub/domain/user/UserService.java
+++ b/src/main/java/br/com/notehub/domain/user/UserService.java
@@ -41,10 +41,6 @@ public interface UserService {
 
     void disallowSubscription(UUID idFromToken, String subscriptionStr);
 
-    void follow(UUID idFromToken, String username);
-
-    void unfollow(UUID idFromToken, String username);
-
     void delete(UUID idFromToken, String password);
 
     User getUser(String username);
@@ -52,12 +48,6 @@ public interface UserService {
     List<User> getAllActiveUsers();
 
     Page<User> findAll(Pageable pageable, String q);
-
-    Page<User> getUserFollowing(Pageable pageable, String q, UUID idFromToken, String username);
-
-    Page<User> getUserFollowers(Pageable pageable, String q, UUID idFromToken, String username);
-
-    Set<String> getUserMutualConnections(UUID id);
 
     List<String> getUserDisplayNameHistory(String username);
 

--- a/src/main/resources/db/migration/V20260609__create_table_follows.sql
+++ b/src/main/resources/db/migration/V20260609__create_table_follows.sql
@@ -1,0 +1,16 @@
+CREATE TABLE follows (
+    follower_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    following_id UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    PRIMARY KEY (follower_id, following_id)
+);
+
+INSERT INTO follows (follower_id, following_id)
+    SELECT follower_id, following_id
+        FROM user_follows
+            ON CONFLICT DO NOTHING;
+
+DROP TABLE user_follows;
+
+CREATE INDEX idx_follows_follower_id ON follows(follower_id);
+CREATE INDEX idx_follows_following_id ON follows(following_id);

--- a/src/test/java/br/com/notehub/implementation/user/UserDeletionTest.java
+++ b/src/test/java/br/com/notehub/implementation/user/UserDeletionTest.java
@@ -1,6 +1,8 @@
 package br.com.notehub.implementation.user;
 
 import br.com.notehub.application.implementation.user.UserServiceImpl;
+import br.com.notehub.domain.follow.FollowService;
+import br.com.notehub.domain.follow.events.UserDeletedEvent;
 import br.com.notehub.domain.note.NoteService;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserRepository;
@@ -10,10 +12,12 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 import java.util.Optional;
+import java.util.Set;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,6 +38,12 @@ public class UserDeletionTest {
     @Mock
     private PasswordEncoder encoder;
 
+    @Mock
+    private FollowService followService;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+
     private User user;
 
     private void mockFindById(User u) {
@@ -53,21 +63,21 @@ public class UserDeletionTest {
 
     @Test
     void shouldDeleteUser_whenPasswordMatches() {
-
         mockFindById(user);
         mockMatches(true);
+        when(followService.getUserFollowersId(user.getId())).thenReturn(Set.of());
+        when(followService.getUserFollowingId(user.getId())).thenReturn(Set.of());
 
         service.delete(user.getId(), user.getPassword());
 
         verify(repository).findById(user.getId());
         verify(repository).delete(user);
         verify(noteService).deleteAllUserHiddenNotes(user);
-
+        verify(eventPublisher).publishEvent(any(UserDeletedEvent.class));
     }
 
     @Test
     void shouldThrowBadCredentialsException_whenPasswordDoesNotMatch() {
-
         mockFindById(user);
         mockMatches(false);
 
@@ -78,7 +88,7 @@ public class UserDeletionTest {
         verify(repository).findById(user.getId());
         verify(repository, never()).delete(user);
         verify(noteService, never()).deleteAllUserHiddenNotes(user);
-
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
 }

--- a/src/test/java/br/com/notehub/implementation/user/UserRelationshipTest.java
+++ b/src/test/java/br/com/notehub/implementation/user/UserRelationshipTest.java
@@ -2,22 +2,30 @@ package br.com.notehub.implementation.user;
 
 import br.com.notehub.application.counter.Counter;
 import br.com.notehub.application.dto.notification.MessageNotification;
-import br.com.notehub.application.implementation.user.UserServiceImpl;
+import br.com.notehub.application.implementation.follow.FollowServiceImpl;
 import br.com.notehub.domain.feed.FeedService;
+import br.com.notehub.domain.follow.Follow;
+import br.com.notehub.domain.follow.FollowRepository;
 import br.com.notehub.domain.notification.NotificationService;
 import br.com.notehub.domain.user.User;
 import br.com.notehub.domain.user.UserRepository;
 import br.com.notehub.infra.exception.CustomExceptions;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.security.access.AccessDeniedException;
 
-import java.util.Optional;
-import java.util.UUID;
+import java.util.*;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
@@ -26,10 +34,13 @@ import static org.mockito.Mockito.*;
 public class UserRelationshipTest {
 
     @InjectMocks
-    private UserServiceImpl service;
+    private FollowServiceImpl service;
 
     @Mock
-    private UserRepository repository;
+    private UserRepository userRepository;
+
+    @Mock
+    private FollowRepository followRepository;
 
     @Mock
     private NotificationService notifier;
@@ -50,14 +61,6 @@ public class UserRelationshipTest {
         return u;
     }
 
-    private void mockfindByIdWithFollowersAndFollowing(User u) {
-        when(repository.findByIdWithFollowersAndFollowing(u.getId())).thenReturn(Optional.of(u));
-    }
-
-    private void mockfindByUsernameWithFollowersAndFollowing(User u) {
-        when(repository.findByUsernameWithFollowersAndFollowing(u.getUsername())).thenReturn(Optional.of(u));
-    }
-
     @BeforeEach
     void setup() {
         follower = createUser("follower@notehub.com.br", "follower");
@@ -66,88 +69,204 @@ public class UserRelationshipTest {
 
     @Test
     void shouldFollowUserAndSendNotification_whenNotAlreadyFollowing() {
-
-        mockfindByIdWithFollowersAndFollowing(follower);
-        mockfindByUsernameWithFollowersAndFollowing(following);
+        when(userRepository.findById(follower.getId())).thenReturn(Optional.of(follower));
+        when(userRepository.findByUsername(following.getUsername())).thenReturn(Optional.of(following));
+        when(followRepository.existsByFollowerIdAndFollowingId(follower.getId(), following.getId())).thenReturn(false);
 
         service.follow(follower.getId(), following.getUsername());
 
-        verify(repository).findByIdWithFollowersAndFollowing(follower.getId());
-        verify(repository).findByUsernameWithFollowersAndFollowing(following.getUsername());
+        verify(followRepository).save(any(Follow.class));
         verify(counter).updateFollowersAndFollowingCount(eq(follower), eq(following), eq(true));
         verify(notifier).notify(eq(follower), eq(following), eq(follower), eq(MessageNotification.of(follower)));
-
     }
 
     @Test
     void shouldUnfollowUserWithoutNotification_whenAlreadyFollowing() {
+        when(userRepository.findById(follower.getId())).thenReturn(Optional.of(follower));
+        when(userRepository.findByUsername(following.getUsername())).thenReturn(Optional.of(following));
+        when(followRepository.existsByFollowerIdAndFollowingId(follower.getId(), following.getId())).thenReturn(true);
 
-        mockfindByIdWithFollowersAndFollowing(follower);
-        mockfindByUsernameWithFollowersAndFollowing(following);
-
-        follower.getFollowing().add(following);
-        following.getFollowers().add(follower);
         service.unfollow(follower.getId(), following.getUsername());
 
-        verify(repository).findByIdWithFollowersAndFollowing(follower.getId());
-        verify(repository).findByUsernameWithFollowersAndFollowing(following.getUsername());
+        verify(followRepository).deleteByFollowerIdAndFollowingId(follower.getId(), following.getId());
         verify(counter).updateFollowersAndFollowingCount(eq(follower), eq(following), eq(false));
         verify(notifier, never()).notify(any(), any(), any(), any());
-
     }
 
     @Test
     void shouldThrowSelfFollowException_whenTryingToFollowSelf() {
-
-        mockfindByIdWithFollowersAndFollowing(follower);
-        mockfindByUsernameWithFollowersAndFollowing(follower);
+        when(userRepository.findById(follower.getId())).thenReturn(Optional.of(follower));
+        when(userRepository.findByUsername(follower.getUsername())).thenReturn(Optional.of(follower));
 
         assertThatThrownBy(() ->
                 service.follow(follower.getId(), follower.getUsername()))
                 .isInstanceOf(CustomExceptions.SelfFollowException.class);
 
-        verify(repository).findByIdWithFollowersAndFollowing(follower.getId());
-        verify(repository).findByUsernameWithFollowersAndFollowing(follower.getUsername());
+        verify(followRepository, never()).save(any());
         verify(counter, never()).updateFollowersAndFollowingCount(any(), any(), any(Boolean.class));
         verify(notifier, never()).notify(any(), any(), any(), any());
-
     }
 
     @Test
     void shouldThrowAlreadyFollowingException_whenFollowingUserAgain() {
-
-        mockfindByIdWithFollowersAndFollowing(follower);
-        mockfindByUsernameWithFollowersAndFollowing(following);
-
-        follower.getFollowing().add(following);
-        following.getFollowers().add(follower);
+        when(userRepository.findById(follower.getId())).thenReturn(Optional.of(follower));
+        when(userRepository.findByUsername(following.getUsername())).thenReturn(Optional.of(following));
+        when(followRepository.existsByFollowerIdAndFollowingId(follower.getId(), following.getId())).thenReturn(true);
 
         assertThatThrownBy(() ->
                 service.follow(follower.getId(), following.getUsername()))
                 .isInstanceOf(CustomExceptions.AlreadyFollowingException.class);
 
-        verify(repository).findByIdWithFollowersAndFollowing(follower.getId());
-        verify(repository).findByUsernameWithFollowersAndFollowing(following.getUsername());
+        verify(followRepository, never()).save(any());
         verify(counter, never()).updateFollowersAndFollowingCount(any(), any(), any(Boolean.class));
         verify(notifier, never()).notify(any(), any(), any(), any());
-
     }
 
     @Test
     void shouldThrowNotFollowingException_whenUnfollowingUserNotFollowed() {
-
-        mockfindByIdWithFollowersAndFollowing(follower);
-        mockfindByUsernameWithFollowersAndFollowing(following);
+        when(userRepository.findById(follower.getId())).thenReturn(Optional.of(follower));
+        when(userRepository.findByUsername(following.getUsername())).thenReturn(Optional.of(following));
+        when(followRepository.existsByFollowerIdAndFollowingId(follower.getId(), following.getId())).thenReturn(false);
 
         assertThatThrownBy(() ->
                 service.unfollow(follower.getId(), following.getUsername()))
                 .isInstanceOf(CustomExceptions.NotFollowingException.class);
 
-        verify(repository).findByIdWithFollowersAndFollowing(follower.getId());
-        verify(repository).findByUsernameWithFollowersAndFollowing(following.getUsername());
+        verify(followRepository, never()).deleteByFollowerIdAndFollowingId(any(), any());
         verify(counter, never()).updateFollowersAndFollowingCount(any(), any(), any(Boolean.class));
         verify(notifier, never()).notify(any(), any(), any(), any());
+    }
 
+    @Test
+    void shouldReturnPageOfUsersThatRequestedUserIsFollowing() {
+        User requesting = createUser("req@mail.com", "req");
+        User target = createUser("target@mail.com", "target");
+        User u1 = createUser("a@mail.com", "a");
+        User u2 = createUser("b@mail.com", "b");
+
+        List<UUID> ids = List.of(u1.getId(), u2.getId());
+        Page<User> expected = new PageImpl<>(List.of(u1, u2));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<Follow> followPage = new PageImpl<>(List.of(
+                new Follow(target, u1),
+                new Follow(target, u2)
+        ));
+
+        when(userRepository.findById(requesting.getId())).thenReturn(Optional.of(requesting));
+        when(userRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
+        when(followRepository.findByFollowerId(eq(target.getId()), any())).thenReturn(followPage);
+        when(userRepository.findAllByIdIn(eq(pageable), eq("q"), argThat(list -> new HashSet<>(list).containsAll(ids)))).thenReturn(expected);
+
+        Page<User> result = service.getUserFollowing(pageable, "q", requesting.getId(), target.getUsername());
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldReturnPageOfUsersThatFollowsRequestedUser() {
+        User requesting = createUser("req@mail.com", "req");
+        User target = createUser("target@mail.com", "target");
+        User u1 = createUser("a@mail.com", "a");
+        User u2 = createUser("b@mail.com", "b");
+
+        List<UUID> ids = List.of(u1.getId(), u2.getId());
+        Page<User> expected = new PageImpl<>(List.of(u1, u2));
+        Pageable pageable = PageRequest.of(0, 10);
+
+        Page<Follow> followPage = new PageImpl<>(List.of(
+                new Follow(u1, target),
+                new Follow(u2, target)
+        ));
+
+        when(userRepository.findById(requesting.getId())).thenReturn(Optional.of(requesting));
+        when(userRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
+        when(followRepository.findByFollowingId(eq(target.getId()), any())).thenReturn(followPage);
+        when(userRepository.findAllByIdIn(eq(pageable), eq("q"), argThat(list -> new HashSet<>(list).containsAll(ids)))).thenReturn(expected);
+
+        Page<User> result = service.getUserFollowers(pageable, "q", requesting.getId(), target.getUsername());
+
+        assertThat(result).isEqualTo(expected);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenRequestingUserNotFound() {
+        UUID id = UUID.randomUUID();
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(userRepository.findById(id)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                service.getUserFollowing(pageable, "q", id, "someone"))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(userRepository).findById(id);
+        verify(userRepository, never()).findByUsername(anyString());
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundException_whenRequestedUserNotFound() {
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(userRepository.findById(follower.getId())).thenReturn(Optional.of(follower));
+        when(userRepository.findByUsername(anyString())).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() ->
+                service.getUserFollowing(pageable, "q", follower.getId(), "unknown"))
+                .isInstanceOf(EntityNotFoundException.class);
+
+        verify(userRepository).findById(follower.getId());
+        verify(userRepository).findByUsername("unknown");
+    }
+
+    @Test
+    void shouldThrowAccessDeniedException_whenAccessIsNotAllowed() {
+        User requesting = createUser("req@mail.com", "req");
+        User target = createUser("tar@mail.com", "tar");
+        target.setProfilePrivate(true);
+        Pageable pageable = PageRequest.of(0, 10);
+
+        when(userRepository.findById(requesting.getId())).thenReturn(Optional.of(requesting));
+        when(userRepository.findByUsername(target.getUsername())).thenReturn(Optional.of(target));
+        when(followRepository.existsByFollowerIdAndFollowingId(target.getId(), requesting.getId())).thenReturn(false);
+
+        assertThatThrownBy(() ->
+                service.getUserFollowing(pageable, "q", requesting.getId(), target.getUsername()))
+                .isInstanceOf(AccessDeniedException.class);
+    }
+
+    @Test
+    void shouldReturnStringSetOfAllUserMutuals() {
+        User u1 = createUser("a@mail.com", "a");
+        User u2 = createUser("b@mail.com", "b");
+
+        Page<Follow> followingPage = new PageImpl<>(List.of(new Follow(follower, u1), new Follow(follower, u2)));
+        Page<Follow> followersPage = new PageImpl<>(List.of(new Follow(u1, follower), new Follow(u2, follower)));
+
+        when(followRepository.findByFollowerId(eq(follower.getId()), any())).thenReturn(followingPage);
+        when(followRepository.findByFollowingId(eq(follower.getId()), any())).thenReturn(followersPage);
+        when(userRepository.findAllById(anyCollection())).thenReturn(List.of(u1, u2));
+
+        Set<String> mutuals = service.getUserMutualConnections(follower.getId());
+
+        assertThat(mutuals).containsExactlyInAnyOrder("a", "b");
+    }
+
+    @Test
+    void shouldReturnEmptySet_whenUserHasNoMutualConnections() {
+        User u1 = createUser("a@mail.com", "a");
+        User u2 = createUser("b@mail.com", "b");
+
+        Page<Follow> followingPage = new PageImpl<>(List.of(new Follow(follower, u1)));
+        Page<Follow> followersPage = new PageImpl<>(List.of(new Follow(u2, follower)));
+
+        when(followRepository.findByFollowerId(eq(follower.getId()), any())).thenReturn(followingPage);
+        when(followRepository.findByFollowingId(eq(follower.getId()), any())).thenReturn(followersPage);
+        when(userRepository.findAllById(anyCollection())).thenReturn(Collections.emptyList());
+
+        Set<String> mutuals = service.getUserMutualConnections(follower.getId());
+
+        assertThat(mutuals).isEmpty();
     }
 
 }

--- a/src/test/java/br/com/notehub/implementation/user/UserRetrievalTest.java
+++ b/src/test/java/br/com/notehub/implementation/user/UserRetrievalTest.java
@@ -16,9 +16,11 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.security.access.AccessDeniedException;
 
-import java.util.*;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -62,264 +64,65 @@ class UserRetrievalTest {
 
     @Test
     void shouldReturnUser_whenUsernameWasFoundAndUserIsActive() {
-
         mockFindByUsername(user);
-
         User result = service.getUser(user.getUsername());
-
         verify(repository).findByUsername(user.getUsername());
-
         assertThat(result).isEqualTo(user);
-
     }
 
     @Test
     void shouldThrowEntityNotFoundException_whenUsernameWasNotFoundOrUserIsInactive() {
-
         when(repository.findByUsername(anyString())).thenReturn(Optional.empty());
-
         assertThatThrownBy(() -> service.getUser(user.getUsername()))
                 .isInstanceOf(EntityNotFoundException.class);
-
         verify(repository).findByUsername(user.getUsername());
-
     }
 
     @Test
     void shouldReturnListOfActiveUsers() {
-
         when(repository.findAllByActiveTrue()).thenReturn(List.of(user));
-
         List<User> result = service.getAllActiveUsers();
-
         verify(repository).findAllByActiveTrue();
-
         assertThat(result).containsExactly(user);
-
     }
 
     @Test
     void shouldReturnPageOfActiveUsersByQuery() {
-
         String query = "tester";
         Page<User> page = new PageImpl<>(List.of(user));
-
         when(repository.findAllActiveUsersByUsernameOrDisplayName(pageable, query)).thenReturn(page);
-
         Page<User> result = service.findAll(pageable, query);
-
         verify(repository).findAllActiveUsersByUsernameOrDisplayName(pageable, query);
-
         assertThat(result).isEqualTo(page);
-
-    }
-
-    @Test
-    void shouldReturnPageOfUsersThatRequestedUserIsFollowing() {
-
-        User requesting = user;
-        User target = createUser("target@mail.com", "target");
-        User u1 = createUser("a@mail.com", "a");
-        User u2 = createUser("b@mail.com", "b");
-
-        List<User> users = List.of(u1, u2);
-        Set<UUID> ids = Set.of(u1.getId(), u2.getId());
-        target.getFollowing().addAll(users);
-
-        Page<User> expected = new PageImpl<>(users);
-
-        mockFindById(requesting);
-        mockFindByUsername(target);
-
-        when(repository.findAllByIdIn(
-                eq(pageable),
-                eq("q"),
-                argThat(list -> new HashSet<>(list).equals(ids))
-        )).thenReturn(expected);
-
-        Page<User> result = service.getUserFollowing(pageable, "q", requesting.getId(), target.getUsername());
-
-        verify(repository).findById(requesting.getId());
-        verify(repository).findByUsername(target.getUsername());
-        verify(repository).findAllByIdIn(
-                eq(pageable),
-                eq("q"),
-                argThat(list -> new HashSet<>(list).equals(ids))
-        );
-
-        assertThat(result).isEqualTo(expected);
-
-    }
-
-    @Test
-    void shouldReturnPageOfUsersThatFollowsRequestedUser() {
-
-        User requesting = user;
-        User target = createUser("target@mail.com", "target");
-        User u1 = createUser("a@mail.com", "a");
-        User u2 = createUser("b@mail.com", "b");
-
-        List<User> users = List.of(u1, u2);
-        Set<UUID> ids = Set.of(u1.getId(), u2.getId());
-        target.getFollowers().addAll(users);
-
-        Page<User> expected = new PageImpl<>(users);
-
-        mockFindById(requesting);
-        mockFindByUsername(target);
-
-        when(repository.findAllByIdIn(
-                eq(pageable),
-                eq("q"),
-                argThat(list -> new HashSet<>(list).equals(ids))
-        )).thenReturn(expected);
-
-        Page<User> result = service.getUserFollowers(pageable, "q", requesting.getId(), target.getUsername());
-
-        verify(repository).findById(requesting.getId());
-        verify(repository).findByUsername(target.getUsername());
-        verify(repository).findAllByIdIn(
-                eq(pageable),
-                eq("q"),
-                argThat(list -> new HashSet<>(list).equals(ids))
-        );
-
-        assertThat(result).isEqualTo(expected);
-
-    }
-
-    @Test
-    void shouldThrowEntityNotFoundException_whenRequestingUserNotFound() {
-
-        UUID id = UUID.randomUUID();
-
-        when(repository.findById(id)).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() ->
-                service.getUserFollowing(pageable, "q", id, "someone"))
-                .isInstanceOf(EntityNotFoundException.class);
-
-        verify(repository).findById(id);
-        verify(repository, never()).findByUsername(anyString());
-        verify(repository, never()).findAllByIdIn(any(), anyString(), anyList());
-
-    }
-
-    @Test
-    void shouldThrowEntityNotFoundException_whenRequestedUserNotFound() {
-
-        mockFindById(user);
-        when(repository.findByUsername(anyString())).thenReturn(Optional.empty());
-
-        assertThatThrownBy(() ->
-                service.getUserFollowing(pageable, "q", user.getId(), "unknown"))
-                .isInstanceOf(EntityNotFoundException.class);
-
-        verify(repository).findById(user.getId());
-        verify(repository).findByUsername("unknown");
-        verify(repository, never()).findAllByIdIn(any(), anyString(), anyList());
-
-    }
-
-    @Test
-    void shouldThrowAccessDeniedException_whenAccessIsNotAllowed() {
-
-        User requesting = createUser("req@mail.com", "req");
-        User target = createUser("tar@mail.com", "tar");
-        target.setProfilePrivate(true);
-
-        mockFindById(requesting);
-        mockFindByUsername(target);
-
-        assertThatThrownBy(() ->
-                service.getUserFollowing(pageable, "q", requesting.getId(), "tar"))
-                .isInstanceOf(AccessDeniedException.class);
-
-        verify(repository).findById(requesting.getId());
-        verify(repository).findByUsername("tar");
-        verify(repository, never()).findAllByIdIn(any(), anyString(), anyList());
-
-    }
-
-    @Test
-    void shouldReturnStringSetOfAllUserMutuals() {
-
-        User u1 = createUser("a@mail.com", "a");
-        User u2 = createUser("b@mail.com", "b");
-
-        List<User> users = List.of(u1, u2);
-
-        user.getFollowers().addAll(users);
-        user.getFollowing().addAll(users);
-
-        when(repository.findByIdWithFollowersAndFollowing(user.getId())).thenReturn(Optional.of(user));
-
-        Set<String> mutuals = service.getUserMutualConnections(user.getId());
-
-        verify(repository).findByIdWithFollowersAndFollowing(user.getId());
-
-        assertThat(mutuals).containsExactlyInAnyOrder("a", "b");
-
-    }
-
-    @Test
-    void shouldReturnEmptySet_whenUserHasNoMutualConnections() {
-
-        user.getFollowers().add(createUser("a@mail.com", "a"));
-        user.getFollowing().add(createUser("b@mail.com", "b"));
-
-        when(repository.findByIdWithFollowersAndFollowing(user.getId())).thenReturn(Optional.of(user));
-
-        Set<String> mutuals = service.getUserMutualConnections(user.getId());
-
-        verify(repository).findByIdWithFollowersAndFollowing(user.getId());
-
-        assertThat(mutuals).isEmpty();
-
     }
 
     @Test
     void shouldReturnListOfUserUsernameHistory() {
-
         List<String> expected = List.of("tester", "new");
-
         mockFindByUsername(user);
         when(historian.getLastFiveUserDisplayName(user)).thenReturn(expected);
-
         List<String> history = service.getUserDisplayNameHistory(user.getUsername());
-
         assertThat(history).containsExactlyElementsOf(expected);
-
     }
 
     @Test
     void shouldReturnListOfUserSubscriptions() {
-
         mockFindById(user);
-
         Set<Subscription> expected = Set.of(Subscription.MAINTENANCE, Subscription.RELEASE);
         Set<Subscription> subscriptions = service.getUserSubscriptions(user.getId());
-
         verify(repository).findById(user.getId());
-
         assertThat(subscriptions).containsExactlyInAnyOrderElementsOf(expected);
-
     }
 
     @Test
     void shouldCleanUsersWithExpiredActivationTime() {
-
         User u1 = createUser("a@mail.com", "a");
         User u2 = createUser("b@mail.com", "b");
         List<User> expired = List.of(u1, u2);
-
         when(repository.findUsersWithExpiredActivationTime(any())).thenReturn(expired);
-
         service.cleanUsersWithExpiredActivationTime();
-
         verify(repository).findUsersWithExpiredActivationTime(any());
         verify(repository).deleteAll(expired);
-
     }
 
 }


### PR DESCRIPTION
### Sumário
Refatoração completa da camada de relacionamentos entre usuários, extraindo o conceito de follow para um domínio próprio e removendo o acoplamento direto entre `User` e as coleções `followers/following`.

A implementação passa a usar a entidade `Follow` como fonte de verdade para os relacionamentos, com persistência própria em `follows`, services dedicados e uso de eventos para manter contadores e efeitos colaterais desacoplados da exclusão de usuário.

### Alterações
- Criado o domínio `follow` com:
  - `Follow`
  - `FollowId`
  - `FollowRepository`
  - `FollowService`
  - `FollowServiceImpl`
- Criado `FollowController` e removidos os endpoints de follow/unfollow/listagens de `UserController`
- Removido o relacionamento `@ManyToMany` entre usuários em `User`
- Removidos métodos legados de `UserService` relacionados a follow, followers, following e mutuals
- Migrada a tabela `user_follows` para `follows` com:
  - chave primária composta
  - `created_at`
  - índices para `follower_id` e `following_id`
- Refatorado `Counter` para trabalhar com increment/decrement de contadores de forma isolada
- Adicionado `UserDeletedEvent` e `FollowEventListener` para tratar limpeza de contadores após exclusão de usuário
- Atualizado `UserServiceImpl` para publicar evento ao deletar usuário
- Atualizados `NoteServiceImpl`, `FlameServiceImpl`, `CommentServiceImpl` e `ReplyServiceImpl` para depender de `FollowService` na validação de acesso bidirecional
- Atualizado `FeedRepository` para limpar eventos não mútuos com base na nova tabela `follows`
- Ajustado `FeedServiceImpl` para usar `FollowRepository` na lógica de visibilidade e fan-out
- Atualizados testes de exclusão e relacionamento de usuários para refletir a nova arquitetura

### Necessidade
A estrutura anterior mantinha os relacionamentos de follow embutidos em `User`, o que aumentava o acoplamento, dificultava a evolução do feed/eventos e tornava a manutenção de contadores e regras de visibilidade mais frágil.

Com essa refatoração, o relacionamento entre usuários passa a ter um domínio próprio, facilitando:
- manutenção do feed fan-out
- validação de acesso para perfis privados
- tratamento de follow/unfollow de forma centralizada
- remoção de efeitos colaterais diretos da entidade `User`

### Teste manual
1. Criar dois usuários e realizar follow/unfollow
2. Confirmar que os contadores de seguidores e seguindo são atualizados corretamente
3. Criar um usuário privado e validar o acesso a notas, flames, comentários e replies com e sem vínculo bidirecional
4. Deletar um usuário com relacionamentos existentes e verificar se os contadores dos usuários afetados são ajustados
5. Validar que o feed continua refletindo corretamente os eventos após a migração para `follows`
6. Confirmar que a migration converte os dados antigos de `user_follows` para `follows`

### Checklist
- [x] Código segue o padrão do projeto
- [x] Documentação atualizada
- [x] Testes atualizados


### Breaking Changes
- Os relacionamentos `followers` e `following` foram removidos da entidade `User`
- Endpoints de follow/unfollow e listagens de seguidores/seguidos foram movidos para `FollowController`
- A tabela `user_follows` foi substituída por `follows`
- Serviços que dependiam diretamente das coleções de `User` agora usam `FollowService` / `FollowRepository`